### PR TITLE
Issue #103: Functions errors on gamestate.gd

### DIFF
--- a/core/autoload/gamestate.gd
+++ b/core/autoload/gamestate.gd
@@ -7,7 +7,7 @@ enum MODE {
 	}
 
 #global signals
-signal log_gamestate(msg)
+signal gamestate_log(msg)
 # network user related
 signal user_join #emit when user is fully registered
 signal user_leave #emit on leave of registered user
@@ -94,7 +94,7 @@ func _ready():
 	local_id = 0
 
 	bind_signal("network_log", "", self, self, MODE.TOGGLE)
-	bind_signal("log_gamestate", "", self, self, MODE.TOGGLE)
+	bind_signal("gamestate_log", "", self, self, MODE.TOGGLE)
 	bind_signal("player_scene", "", self, self, MODE.TOGGLE)
 	bind_signal("player_id", "", self, self, MODE.TOGGLE)
 	
@@ -111,23 +111,23 @@ func bind_signal(signal_name : String, method : String, obj : Object, obj2 : Obj
 	if mode == MODE.TOGGLE:  
 		if obj.is_connected(signal_name, obj2, method):
 			obj.disconnect(signal_name, obj2, method)
-			emit_signal("log_gamestate", "disconnect signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
+			emit_signal("gamestate_log", "disconnect signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
 		else:
 			obj.connect(signal_name, obj2, method)
-			emit_signal("log_gamestate", "connect signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
+			emit_signal("gamestate_log", "connect signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
 	
 	elif mode == MODE.CONNECT : #connect
 		if not obj.is_connected(signal_name, obj2, method):
 			obj.connect(signal_name, obj2, method)
 		else:
-			emit_signal("log_gamestate", "tried to connect already connected signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
+			emit_signal("gamestate_log", "tried to connect already connected signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
 	
 	elif mode == MODE.DISCONNECT : #disconnect
 		if obj.is_connected(signal_name, obj2, method):
 			obj.disconnect(signal_name, obj2, method)
-			emit_signal("log_gamestate", "disconnect signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
+			emit_signal("gamestate_log", "disconnect signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
 		else:
-			emit_signal("log_gamestate", "tried to disconnect a disconnected signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
+			emit_signal("gamestate_log", "tried to disconnect a disconnected signal", signal_name," from ", str(obj)," to ", str(obj2), "::", method)
 
 
 #################
@@ -135,13 +135,13 @@ func bind_signal(signal_name : String, method : String, obj : Object, obj2 : Obj
 
 
 func queue_attach(path : String, node, permanent : bool = false) -> void: #node is variant
-	emit_signal("log_gamestate", str("attach queue(permanent: ", str(permanent),"): ", path, "(", node, ")")) 
+	emit_signal("gamestate_log", str("attach queue(permanent: ", str(permanent),"): ", path, "(", node, ")")) 
 	var packedscene
 	if node is String:
 		packedscene = ResourceLoader.load(node)
-		emit_signal("log_gamestate", str("loading resource in queue_attach(", path, ", ", node, ", ", permanent,")"))
+		emit_signal("gamestate_log", str("loading resource in queue_attach(", path, ", ", node, ", ", permanent,")"))
 		if not packedscene:
-			emit_signal("log_gamestate", str("error loading resource in queue_attach(", path, ", ", node, ", ", permanent,")"))
+			emit_signal("gamestate_log", str("error loading resource in queue_attach(", path, ", ", node, ", ", permanent,")"))
 			return
 	if not packedscene:
 		packedscene = node
@@ -155,7 +155,7 @@ func queue_attach(path : String, node, permanent : bool = false) -> void: #node 
 	bind_signal("tree_changed","_on_queue_attach_on_tree_change", get_tree(), self, MODE.CONNECT) 
 
 func queue_tree_signal(path : String, signal_name : String, permanent : bool = false) -> void:
-	emit_signal("log_gamestate", "signal queue(permanent %s): %s(%s)" % [permanent, path, signal_name])
+	emit_signal("gamestate_log", "signal queue(permanent %s): %s(%s)" % [permanent, path, signal_name])
 	_queue_attach[path] = {
 			path = path,
 			permanent = permanent,
@@ -229,7 +229,7 @@ func server_set_mode(host : String = "localhost"):
 		bind_signal("network_peer_connected", "_on_server_tree_user_connected", get_tree(), self, MODE.CONNECT)
 		bind_signal("network_peer_disconnected", "_on_server_tree_user_disconnected", get_tree(), self, MODE.CONNECT)
 
-		emit_signal("log_gamestate", "network server id %s" % server.connection.get_unique_id())
+		emit_signal("gamestate_log", "network server id %s" % server.connection.get_unique_id())
 		network_id = server.connection.get_unique_id()
 		emit_signal("player_id", network_id)
 	else:
@@ -284,10 +284,10 @@ func change_scene(scene : String) -> void:
 	var scenes = options.scenes
 	if not scene in scenes:
 		emit_signal("scene_change_error", "No such scene %s" % scene)
-		emit_signal("log_gamestate", "No such scene %s" % scene)
+		emit_signal("gamestate_log", "No such scene %s" % scene)
 		return
 	
-	emit_signal("log_gamestate", "change_scene to %s" % scene)
+	emit_signal("gamestate_log", "change_scene to %s" % scene)
 	var error = get_tree().change_scene(scenes[scene].path)
 	if error == 0 :
 		emit_signal("gamestate_log", "changing scene okay(%s)" % error)
@@ -295,7 +295,7 @@ func change_scene(scene : String) -> void:
 		emit_signal("scene_change")
 		emit_signal("scene_change_name", scene)
 	else:
-		emit_signal("log_gamestate", "error changing scene %s" % error)
+		emit_signal("gamestate_log", "error changing scene %s" % error)
 
 
 
@@ -331,10 +331,10 @@ func player_register(pdata : Dictionary, localplayer : bool = false, opt_id : St
 	elif pdata.has("id"):
 		id = pdata.id
 	else:
-		emit_signal("log_gamestate", "player data should have id or be a local")
+		emit_signal("gamestate_log", "player data should have id or be a local")
 		return
 	
-	emit_signal("log_gamestate", "registered player(", str(id), "): ", str(pdata))
+	emit_signal("gamestate_log", "registered player(%s): %s" % [id, pdata])
 	var player = {}
 	player["data"] = pdata
 	player["obj"] = options.player_scene.instance()
@@ -379,7 +379,7 @@ remote func register_client(id : int, pdata : Dictionary) -> void:
 				rpc_id(id, "register_client", pid, players[p].data)
 
 remote func unregister_client(id : int) -> void:
-	emit_signal("log_gamestate", "unregister client (%s)" % id)
+	emit_signal("gamestate_log", "unregister client (%s)" % id)
 	if players.has(id):
 		emit_signal("user_name_disconnected", "%s" % player_get("name", id))
 		if players[id].obj:
@@ -424,23 +424,23 @@ func player_remap_id(old_id : int, new_id : int) -> void:
 		players.erase(old_id)
 		players[new_id] = player
 		player["id"] = new_id
-		emit_signal("log_gamestate", "remap player old_id(%s), new_id(%s)" % [old_id, new_id])
+		emit_signal("gamestate_log", "remap player old_id(%s), new_id(%s)" % [old_id, new_id])
 		if player.has("path"):
 			var node = player.obj
 			node.name = "%s" % new_id
 			var world = get_tree().current_scene
-			emit_signal("log_gamestate", "remap player, old path %s to %s" % [player.path, world.get_path_to(node)])
+			emit_signal("gamestate_log", "remap player, old path %s to %s" % [player.path, world.get_path_to(node)])
 			player["path"] = world.get_path_to(node)
 			node.set_network_master(new_id)
 
 func create_player(id : int) -> void:
 	var world = get_tree().current_scene
 	if players[id].has("world") and players[id]["world"] == str(world):
-		emit_signal("log_gamestate", "player(%s) already added, %s" % [id, players[id]])
+		emit_signal("gamestate_log", "player(%s) already added, %s" % [id, players[id]])
 		return
 	var spawn_pcount =  world.get_node("spawn_points").get_child_count()
 	var spawn_pos = randi() % spawn_pcount
-	emit_signal("log_gamestate", "select spawn point(%s/%s)" % [spawn_pos, spawn_pcount])
+	emit_signal("gamestate_log", "select spawn point(%s/%s)" % [spawn_pos, spawn_pcount])
 	spawn_pos = world.get_node("spawn_points").get_child(spawn_pos).translation
 	var player = players[id].obj
 #	player.flies = true # MUST CHANGE WHEN COLLISIONS ARE DONE
@@ -455,7 +455,7 @@ func create_player(id : int) -> void:
 		printd("create player set_network_master player id(%s) network id(%s)" % [id, players[id].id])
 		player.set_network_master(players[id].id) #set unique id as master
 	
-	emit_signal("log_gamestate", "==create player(%s) %s; name(%s)" % [id, players[id], players[id].data.username])
+	emit_signal("gamestate_log", "==create player(%s) %s; name(%s)" % [id, players[id], players[id].data.username])
 	world.get_node("players").add_child(player)
 	players[id]["world"] = "%s" % world
 	players[id]["path"] = world.get_path_to(player)
@@ -503,10 +503,10 @@ func log_all_signals() -> void:
 		
 func log_all_signals_print_1(signal_name : String):
 	printd(str("==========signal0 ", signal_name," ================"))
-func log_all_signals_print_2(a1 : int, signal_name : String):
+func log_all_signals_print_2(a1, signal_name : String):
 	printd(str("==========signal1 ", signal_name," ================"))
 	printd(str(a1))
-func log_all_signals_print_3(a1 : int, a2 : int, signal_name : String):
+func log_all_signals_print_3(a1, a2, signal_name : String):
 	printd(str("==========signal2 ", signal_name," ================"))
 	printd(str(a1, a2))
 
@@ -517,10 +517,10 @@ func log_all_signals_print_3(a1 : int, a2 : int, signal_name : String):
 
 func loading_done(var error : int) -> void:
 	if error == OK or error == ERR_FILE_EOF:
-		emit_signal("log_gamestate", "changing scene okay(%s)" % level_loader.error)
+		emit_signal("gamestate_log", "changing scene okay(%s)" % level_loader.error)
 		emit_signal("loading_done")
 	else:
-		emit_signal("log_gamestate", "error changing scene %s" % level_loader.error)
+		emit_signal("gamestate_log", "error changing scene %s" % level_loader.error)
 		emit_signal("loading_error", "Error! " + str(error))
 
 func load_level(var resource) -> void: #Resource is variant
@@ -583,7 +583,7 @@ func _on_queue_attach_on_tree_change() -> void:
 	if get_tree():
 		if _queue_attach_on_tree_change_prev_scene != str(get_tree().current_scene):
 			_queue_attach_on_tree_change_prev_scene = str(get_tree().current_scene)
-			emit_signal("log_gamestate", "qatc: Scene changed %s" % _queue_attach_on_tree_change_prev_scene)
+			emit_signal("gamestate_log", "qatc: Scene changed %s" % _queue_attach_on_tree_change_prev_scene)
 			for p in _queue_attach:
 				if _queue_attach[p].has("node"):
 					emit_signal("gamestate_log", "qatc: node %s(%s) permanent %s" % [p, _queue_attach[p].node, _queue_attach[p].permanent])
@@ -602,7 +602,7 @@ func _on_queue_attach_on_tree_change() -> void:
 					if _queue_attach[p].has("signal"):
 						var sig = _queue_attach[p].signal
 						if not _queue_attach[p].permanent:
-							emit_signal("log_gamestate", "qatc, emit and remove: %s(%s) permanent %s" % [p, _queue_attach[p].signal, _queue_attach[p].permanent])
+							emit_signal("gamestate_log", "qatc, emit and remove: %s(%s) permanent %s" % [p, _queue_attach[p].signal, _queue_attach[p].permanent])
 							_queue_attach.erase(p)
 							emit_signal(sig)
 						else:
@@ -615,7 +615,7 @@ func _on_queue_attach_on_tree_change() -> void:
 					obj.add_child(obj2.instance())
 					_queue_attach_on_tree_change_lock = false
 					if not _queue_attach[p].permanent:
-						emit_signal("log_gamestate", "qatc, attached and removed: %s(%s) permanent %s" % [p, _queue_attach[p].node, _queue_attach[p].permanent])
+						emit_signal("gamestate_log", "qatc, attached and removed: %s(%s) permanent %s" % [p, _queue_attach[p].node, _queue_attach[p].permanent])
 						_queue_attach.erase(p)
 						scene.print_tree_pretty()
 					else:
@@ -660,24 +660,24 @@ func _on_server_tree_changed() -> void:
 		emit_signal("network_log", "reconnect server to tree")
 
 func _on_server_user_connected(id : int) -> void:
-	emit_signal("log_gamestate", "user connected %s" % id)
+	emit_signal("gamestate_log", "user connected %s" % id)
 
 func _on_server_user_disconnected(id : int) -> void:
-	emit_signal("log_gamestate", "user disconnected %s" % id)
+	emit_signal("gamestate_log", "user disconnected %s" % id)
 
 func _on_server_tree_user_connected(id : int) -> void:
-	emit_signal("log_gamestate", "tree user connected %s" % id)
+	emit_signal("gamestate_log", "tree user connected %s" % id)
 
 func _on_server_tree_user_disconnected(id : int) -> void:
-	emit_signal("log_gamestate", "tree user disconnected %s" % id)
+	emit_signal("gamestate_log", "tree user disconnected %s" % id)
 	unregister_client(id)
 
 
 func _on_player_scene() -> void:
-	emit_signal("log_gamestate", "scene is player ready, checking players(%s)" % players.size())
+	emit_signal("gamestate_log", "scene is player ready, checking players(%s)" % players.size())
 	if options.debug:
 		for p in players:
-			emit_signal("log_gamestate", "player %s" % players[p])
+			emit_signal("gamestate_log", "player %s" % players[p])
 	for p in players:
 		create_player(p)
 	
@@ -708,14 +708,14 @@ func _connected_fail() -> void:
 	emit_signal("connection_failed")
 
 func _on_connection_failed() -> void:
-	emit_signal("log_gamestate", "client connection failed to %s(%s):%s" % [player_get("host"), player_get("ip"), player_get("port")])
+	emit_signal("gamestate_log", "client connection failed to %s(%s):%s" % [player_get("host"), player_get("ip"), player_get("port")])
 	bind_signal("connection_failed", '', get_tree(), self, MODE.DISCONNECT)
 	bind_signal("connected_to_server", '', get_tree(), self, MODE.DISCONNECT)
 	RoleClient = false
 	emit_signal("network_error", "Error connecting to server %s(%s):%s" % [player_get("host"), player_get("ip"), player_get("port")])
 
 func _on_connected_to_server() -> void:
-	emit_signal("log_gamestate", "client connected to %s(%s):%s" % [player_get("host"), player_get("ip"), player_get("port")])
+	emit_signal("gamestate_log", "client connected to %s(%s):%s" % [player_get("host"), player_get("ip"), player_get("port")])
 	bind_signal("connection_failed", '', get_tree(), self, MODE.DISCONNECT)
 	bind_signal("connected_to_server", '', get_tree(), self, MODE.DISCONNECT)
 	RoleClient = true


### PR DESCRIPTION
Fixed:
- log_all_signals_print_x type casting errors -> it's best not to specify argument type here and function will handle anything in correct manner.
- Error calling method from signal 'log_gamestate' -> previous signal name is 'gslog', so now it should be 'gamestate_log'. Sometimes signal is referenced as 'log_gamestate' so it's causing confusion. All calls unified to `gamestate_log`.