### PR TITLE
Audio tour node made. Plays OGG files.

### DIFF
--- a/assets/AudioTour/AudioSphere.gd
+++ b/assets/AudioTour/AudioSphere.gd
@@ -1,0 +1,15 @@
+extends "res://assets/Interactable/Interactable.gd"
+
+
+export var audio_file : AudioStreamOGGVorbis = AudioStreamOGGVorbis.new()
+
+
+func _ready() -> void :
+	audio_file.loop = false
+	$Audio.stream = audio_file
+
+
+#warning-ignore:unused_argument
+func play_sound(interactor_ray_cast):
+	#Player requested audio. Play the audio.
+	$Audio.play()

--- a/assets/AudioTour/AudioSphere.tscn
+++ b/assets/AudioTour/AudioSphere.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://assets/Interactable/Interactable.tscn" type="PackedScene" id=1]
+[ext_resource path="res://assets/AudioTour/AudioSphere.gd" type="Script" id=2]
+[ext_resource path="res://sounds/ding7.ogg" type="AudioStream" id=3]
+
+[sub_resource type="SphereMesh" id=1]
+radius = 0.06
+height = 0.12
+radial_segments = 32
+rings = 16
+
+[sub_resource type="BoxShape" id=2]
+extents = Vector3( 0.05, 0.05, 0.05 )
+
+[node name="AudioSphere" instance=ExtResource( 1 )]
+script = ExtResource( 2 )
+display_info = "play audio recording"
+audio_file = ExtResource( 3 )
+
+[node name="ImmediateGeometry" type="MeshInstance" parent="." index="0"]
+mesh = SubResource( 1 )
+material/0 = null
+
+[node name="Audio" type="AudioStreamPlayer" parent="." index="1"]
+
+[node name="CollisionShape" type="CollisionShape" parent="." index="2"]
+shape = SubResource( 2 )
+[connection signal="interacted_with" from="." to="." method="play_sound"]

--- a/sounds/ding7.ogg
+++ b/sounds/ding7.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e54337df31ce757059a1b092d9faee7d1605b51f695644ba1dfcf30dab804c
+size 36852


### PR DESCRIPTION
Specify which file to use as the audio by clicking on the Audio File
property in the Inspector tab when the AudioTour node is highlighted in the tree.