### PR TITLE
Chat improvements.

### DIFF
--- a/Interface/Hud/Chat/Chat.gd
+++ b/Interface/Hud/Chat/Chat.gd
@@ -71,7 +71,7 @@ remotesync func _append_text_to_chat(new_text: String) -> void:
 
 func fade_chat() -> void :
 	#Cause the chat to fade into being invisible.
-	hide()
+	$ChatAnims.play("Visibility")
 
 
 func lower_chat() -> void :
@@ -88,7 +88,7 @@ func raise_chat() -> void :
 
 func show_chat() -> void :
 	#Show the chat to the player.
-	show()
+	$ChatAnims.play_backwards("Visibility")
 
 
 

--- a/Interface/Hud/Chat/Chat.gd
+++ b/Interface/Hud/Chat/Chat.gd
@@ -8,6 +8,9 @@ extends PanelContainer
 onready var _chat_display_node: RichTextLabel = $"V/RichTextLabel"
 onready var _chat_input_node: LineEdit = $"V/ChatInput"
 
+#How large I was before getting minimized.
+onready var _panel_size : Vector2 = rect_size
+
 #Where the chat box is when fully open.
 const CHAT_RAISED_MARGIN_TOP = -198
 const CHAT_LOWER_MARGIN_TOP = -60
@@ -80,16 +83,34 @@ func _toggle_chat_window() -> void :
 	#Chat window is visible, minimize it.
 	if _chat_window_present :
 		_chat_window_present = false
-		fade_chat()
+		
+		#Make Chat smaller.
+		_chat_display_node.hide()
+		_chat_input_node.hide()
+		
+		rect_size = Vector2( 0,0 )
 	
-	#Chat window is currently minimized.
+	#Chat window is currently minimized, make it have a presence again.
 	else :
 		_chat_window_present = true
-		show_chat()
+		
+		#Make Chat have a  presence again.
+		rect_size = _panel_size
+		_chat_display_node.show()
+		_chat_input_node.show()
+	
+	#If something has made me invisible before this method was called, make
+	#myself visible again.
+	visible = true
 
 
 func fade_chat() -> void :
 	#Cause the chat to fade into being invisible.
+	#Meant to be called from somewhere else. Usually from a group call.
+	#Don't play the fading animation if I am already invisible.
+	if visible == false : return
+	
+	#Make Chat invisible. 
 	$ChatAnims.play("Visibility")
 
 
@@ -107,6 +128,11 @@ func raise_chat() -> void :
 
 func show_chat() -> void :
 	#Show the chat to the player.
+	#Meant to be called from somewhere else. Usually from a group call.
+	#Don't do anything if Chat is already displayed.
+	if visible : return
+	
+	#Make chat visible.
 	$ChatAnims.play_backwards("Visibility")
 
 

--- a/Interface/Hud/Chat/Chat.gd
+++ b/Interface/Hud/Chat/Chat.gd
@@ -15,6 +15,9 @@ const CHAT_LOWER_MARGIN_TOP = -60
 var _active: bool = false
 var _chat_is_raised : bool = false
 
+#True when chat window is active, false when chat window is minimized.
+var _chat_window_present : bool = true
+
 
 func _unhandled_input(event: InputEvent) -> void:
 	if not visible or _active :
@@ -45,6 +48,9 @@ func _unhandled_input(event: InputEvent) -> void:
 			#Scroll upwards.
 			var _v_scroll_bar : VScrollBar = _chat_display_node.get_v_scroll()
 			_v_scroll_bar.value = _v_scroll_bar.value + _v_scroll_bar.page
+		
+		elif event.scancode == KEY_Q :
+			_toggle_chat_window()
 
 
 func _on_LineEdit_text_entered(new_text: String) -> void:
@@ -67,6 +73,19 @@ remotesync func _append_text_to_chat(new_text: String) -> void:
 
 	#warning-ignore:return_value_discarded
 	_chat_display_node.append_bbcode(new_text)
+
+
+func _toggle_chat_window() -> void :
+	#This changes the chat between window active and window minimized.
+	#Chat window is visible, minimize it.
+	if _chat_window_present :
+		_chat_window_present = false
+		fade_chat()
+	
+	#Chat window is currently minimized.
+	else :
+		_chat_window_present = true
+		show_chat()
 
 
 func fade_chat() -> void :

--- a/Interface/Hud/Chat/Chat.gd
+++ b/Interface/Hud/Chat/Chat.gd
@@ -104,7 +104,7 @@ func _toggle_chat_window() -> void :
 	visible = true
 
 
-func fade_chat() -> void :
+func hide_chat() -> void :
 	#Cause the chat to fade into being invisible.
 	#Meant to be called from somewhere else. Usually from a group call.
 	#Don't play the fading animation if I am already invisible.

--- a/Interface/Hud/Chat/Chat.gd
+++ b/Interface/Hud/Chat/Chat.gd
@@ -1,6 +1,8 @@
 extends PanelContainer
 """
 	Chat Scene Script
+	
+	We are part of the group named Chat.
 """
 
 onready var _chat_display_node: RichTextLabel = $"V/RichTextLabel"
@@ -67,6 +69,11 @@ remotesync func _append_text_to_chat(new_text: String) -> void:
 	_chat_display_node.append_bbcode(new_text)
 
 
+func fade_chat() -> void :
+	#Cause the chat to fade into being invisible.
+	hide()
+
+
 func lower_chat() -> void :
 	#Make the chat as small as possible.
 	margin_top = CHAT_LOWER_MARGIN_TOP
@@ -77,3 +84,11 @@ func raise_chat() -> void :
 	#Bring the chat up to the maximum height.
 	margin_top = CHAT_RAISED_MARGIN_TOP
 	_chat_is_raised = true
+
+
+func show_chat() -> void :
+	#Show the chat to the player.
+	show()
+
+
+

--- a/Interface/Hud/Chat/Chat.tscn
+++ b/Interface/Hud/Chat/Chat.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://Themes/Fonts/MainMenuFont.tres" type="DynamicFont" id=1]
 [ext_resource path="res://Themes/StyleBoxes/MainMenuFocusStyle.tres" type="StyleBox" id=2]
@@ -8,7 +8,6 @@
 [ext_resource path="res://Themes/StyleBoxes/ChatMainBGPanel.tres" type="StyleBox" id=6]
 [ext_resource path="res://Interface/Hud/Chat/Chat.gd" type="Script" id=7]
 [ext_resource path="res://Interface/Hud/Chat/ChatInput.gd" type="Script" id=8]
-
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0, 0, 0, 0.392157 )
@@ -147,6 +146,21 @@ TabContainer/styles/tab_bg = SubResource( 8 )
 TabContainer/styles/tab_disabled = SubResource( 9 )
 TabContainer/styles/tab_fg = SubResource( 10 )
 
+[sub_resource type="Animation" id=12]
+resource_name = "Visibility"
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 1 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
+}
+
 [node name="Chat" type="PanelContainer" groups=[
 "Chat",
 ]]
@@ -189,4 +203,7 @@ editable = false
 placeholder_text = "'Enter' to type. 'V' to toggle. 'T' or 'G' to scroll"
 placeholder_alpha = 1.0
 script = ExtResource( 8 )
+
+[node name="ChatAnims" type="AnimationPlayer" parent="."]
+anims/Visibility = SubResource( 12 )
 [connection signal="text_entered" from="V/ChatInput" to="." method="_on_LineEdit_text_entered"]

--- a/Interface/Hud/Chat/Chat.tscn
+++ b/Interface/Hud/Chat/Chat.tscn
@@ -200,7 +200,7 @@ margin_right = 399.0
 margin_bottom = 58.0
 mouse_filter = 2
 editable = false
-placeholder_text = "'Enter' to type. 'V' to toggle. 'T' or 'G' to scroll"
+placeholder_text = "'Enter'=type 'V'=toggle 'T'/'G'=scroll 'Q'=display"
 placeholder_alpha = 1.0
 script = ExtResource( 8 )
 

--- a/Interface/Hud/Chat/Chat.tscn
+++ b/Interface/Hud/Chat/Chat.tscn
@@ -187,5 +187,6 @@ margin_bottom = 58.0
 mouse_filter = 2
 editable = false
 placeholder_text = "'Enter' to type. 'V' to toggle. 'T' or 'G' to scroll"
+placeholder_alpha = 1.0
 script = ExtResource( 8 )
 [connection signal="text_entered" from="V/ChatInput" to="." method="_on_LineEdit_text_entered"]

--- a/Interface/Hud/Chat/Chat.tscn
+++ b/Interface/Hud/Chat/Chat.tscn
@@ -147,7 +147,9 @@ TabContainer/styles/tab_bg = SubResource( 8 )
 TabContainer/styles/tab_disabled = SubResource( 9 )
 TabContainer/styles/tab_fg = SubResource( 10 )
 
-[node name="Chat" type="PanelContainer"]
+[node name="Chat" type="PanelContainer" groups=[
+"Chat",
+]]
 anchor_top = 1.0
 anchor_bottom = 1.0
 margin_top = -60.0


### PR DESCRIPTION
Chat can now be toggled on and off by the player. 
Other events can tell Chat to disappear by calling get_tree().call_group( "Chat", "hide_chat" )

Some UX improvements could be made in regard to how the player can manually toggle the visibility of the chat. It needs to be animated and given a notification thing for the player to know that a message has been sent while visibility toggled.