### PR TITLE
Connect interacted_with to play_sound.

### DIFF
--- a/Utilities/AudioTour/AudioSphere.tscn
+++ b/Utilities/AudioTour/AudioSphere.tscn
@@ -26,3 +26,4 @@ stream = ExtResource( 3 )
 
 [node name="CollisionShape" type="CollisionShape" parent="." index="2"]
 shape = SubResource( 2 )
+[connection signal="interacted_with" from="." to="." method="play_sound"]


### PR DESCRIPTION
The AudioSphere did not have it's signal connected properly for some
reason. This commit fixes that. Now when the player interacts with the
AudioSphere it will actually play the audio.

It basically fixes a minor oversight that prevented AudioSphere from working right.