### PR TITLE
Remove AudioSphere model and add intro AudioSphere

### DIFF
--- a/Utilities/AudioTour/AudioSphere.tscn
+++ b/Utilities/AudioTour/AudioSphere.tscn
@@ -1,16 +1,10 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://Utilities/AudioTour/AudioSphere.gd" type="Script" id=1]
 [ext_resource path="res://Utilities/Interactable/Interactable.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Worlds/MoonTown/Assets/Audio_Tour_Markers/Audio_Tour_intro.ogg" type="AudioStream" id=3]
 
-[sub_resource type="SphereMesh" id=1]
-radius = 0.06
-height = 0.12
-radial_segments = 32
-rings = 16
-
-[sub_resource type="BoxShape" id=2]
+[sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.05, 0.05, 0.05 )
 
 [node name="AudioSphere" groups=[
@@ -19,13 +13,9 @@ extents = Vector3( 0.05, 0.05, 0.05 )
 script = ExtResource( 1 )
 display_info = "play audio recording"
 
-[node name="ImmediateGeometry" type="MeshInstance" parent="." index="0"]
-mesh = SubResource( 1 )
-material/0 = null
-
-[node name="Audio" type="AudioStreamPlayer" parent="." index="1"]
+[node name="Audio" type="AudioStreamPlayer" parent="." index="0"]
 stream = ExtResource( 3 )
 
-[node name="CollisionShape" type="CollisionShape" parent="." index="2"]
-shape = SubResource( 2 )
+[node name="CollisionShape" type="CollisionShape" parent="." index="1"]
+shape = SubResource( 1 )
 [connection signal="interacted_with" from="." to="." method="play_sound"]

--- a/Worlds/MoonTown/Constructs/Moon_Town_Master/Moon_Town_Master.tscn
+++ b/Worlds/MoonTown/Constructs/Moon_Town_Master/Moon_Town_Master.tscn
@@ -416,6 +416,10 @@ shadow_color = Color( 0.423529, 0.423529, 0.423529, 1 )
 [node name="Audio_Tour_Marker_Indoor_intro" type="Spatial" parent="Audio_Tour_Markers" index="0"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 7.2642, 10.0833, -21.0216 )
 
+[node name="AudioSphere" parent="Audio_Tour_Markers/Audio_Tour_Marker_Indoor_intro" index="0" instance=ExtResource( 32 )]
+display_info = "play indoor audio tour introduction."
+audio_file = ExtResource( 39 )
+
 [node name="Audio_Tour_Marker_Indoor" parent="Audio_Tour_Markers" index="1" instance=ExtResource( 34 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.329642, 10.033, -18.1257 )
 


### PR DESCRIPTION
This commit removes the ImmediateGeometry from AudioSphere and creates a
new AudioSphere that plays the AudioTour Introduction.