### PR TITLE
Add ExtraInfoDisplay

### DIFF
--- a/Assets/Interface/ExtraInfoDisplay.tres
+++ b/Assets/Interface/ExtraInfoDisplay.tres
@@ -1,0 +1,152 @@
+[gd_resource type="Theme" load_steps=14 format=2]
+
+[ext_resource path="res://Assets/Interface/Fonts/MainMenuFont.tres" type="DynamicFont" id=1]
+[ext_resource path="res://Assets/Interface/StyleBoxes/MainMenuFocusStyle.tres" type="StyleBox" id=2]
+
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0.6, 0.6, 0.6, 0 )
+
+[sub_resource type="StyleBoxFlat" id=2]
+bg_color = Color( 0, 0, 0, 0.588235 )
+
+[sub_resource type="StyleBoxFlat" id=3]
+content_margin_left = 2.0
+content_margin_right = 2.0
+content_margin_top = 2.0
+content_margin_bottom = 2.0
+bg_color = Color( 0, 0, 0, 0 )
+
+[sub_resource type="StyleBoxFlat" id=4]
+bg_color = Color( 1, 1, 1, 1 )
+draw_center = false
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+
+[sub_resource type="StyleBoxFlat" id=5]
+content_margin_left = 5.0
+content_margin_right = 5.0
+content_margin_top = 5.0
+content_margin_bottom = 5.0
+bg_color = Color( 0.0705882, 0.0705882, 0.0705882, 0.729412 )
+
+[sub_resource type="StyleBoxFlat" id=6]
+bg_color = Color( 0.0901961, 0.0901961, 0.0901961, 1 )
+
+[sub_resource type="StyleBoxFlat" id=7]
+bg_color = Color( 0.101961, 0.101961, 0.101961, 0.901961 )
+
+[sub_resource type="StyleBoxFlat" id=8]
+bg_color = Color( 0, 0, 0, 1 )
+
+[sub_resource type="StyleBoxFlat" id=9]
+content_margin_left = 10.0
+content_margin_right = 10.0
+content_margin_top = 10.0
+content_margin_bottom = 10.0
+bg_color = Color( 0.120504, 0.120504, 0.120504, 0.588235 )
+
+[sub_resource type="StyleBoxEmpty" id=10]
+
+[sub_resource type="StyleBoxFlat" id=11]
+content_margin_left = 10.0
+content_margin_right = 10.0
+bg_color = Color( 0, 0, 0, 0.588235 )
+
+[resource]
+default_font = ExtResource( 1 )
+Button/colors/font_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+Button/colors/font_color_disabled = Color( 0.9, 0.9, 0.9, 0.2 )
+Button/colors/font_color_hover = Color( 0.941176, 0.941176, 0.941176, 1 )
+Button/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+Button/constants/hseparation = 20
+Button/fonts/font = ExtResource( 1 )
+Button/styles/disabled = SubResource( 1 )
+Button/styles/focus = ExtResource( 2 )
+Button/styles/hover = ExtResource( 2 )
+Button/styles/normal = SubResource( 2 )
+Button/styles/pressed = null
+Label/colors/font_color = Color( 1, 1, 1, 1 )
+Label/colors/font_color_shadow = Color( 0, 0, 0, 0 )
+Label/colors/font_outline_modulate = Color( 1, 1, 1, 1 )
+Label/constants/line_spacing = 3
+Label/constants/shadow_as_outline = 0
+Label/constants/shadow_offset_x = 1
+Label/constants/shadow_offset_y = 1
+Label/fonts/font = null
+Label/styles/normal = SubResource( 3 )
+LineEdit/colors/clear_button_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+LineEdit/colors/clear_button_color_pressed = Color( 1, 1, 1, 1 )
+LineEdit/colors/cursor_color = Color( 0.941176, 0.941176, 0.941176, 1 )
+LineEdit/colors/font_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+LineEdit/colors/font_color_selected = Color( 0, 0, 0, 1 )
+LineEdit/colors/selection_color = Color( 0.490196, 0.490196, 0.490196, 1 )
+LineEdit/constants/minimum_spaces = 12
+LineEdit/fonts/font = null
+LineEdit/icons/clear = null
+LineEdit/styles/focus = SubResource( 4 )
+LineEdit/styles/normal = SubResource( 5 )
+LineEdit/styles/read_only = null
+Panel/styles/panel = null
+Panel/styles/panelf = null
+Panel/styles/panelnc = null
+PopupMenu/colors/font_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+PopupMenu/colors/font_color_accel = Color( 0.7, 0.7, 0.7, 0.8 )
+PopupMenu/colors/font_color_disabled = Color( 0.4, 0.4, 0.4, 0.8 )
+PopupMenu/colors/font_color_hover = Color( 0.878431, 0.878431, 0.878431, 1 )
+PopupMenu/constants/hseparation = 4
+PopupMenu/constants/vseparation = 4
+PopupMenu/fonts/font = null
+PopupMenu/icons/checked = null
+PopupMenu/icons/radio_checked = null
+PopupMenu/icons/radio_unchecked = null
+PopupMenu/icons/submenu = null
+PopupMenu/icons/unchecked = null
+PopupMenu/styles/hover = null
+PopupMenu/styles/labeled_separator_left = null
+PopupMenu/styles/labeled_separator_right = null
+PopupMenu/styles/panel = SubResource( 6 )
+PopupMenu/styles/panel_disabled = null
+PopupMenu/styles/separator = null
+ProgressBar/colors/font_color = Color( 0.941176, 0.941176, 0.941176, 1 )
+ProgressBar/colors/font_color_shadow = Color( 0, 0, 0, 1 )
+ProgressBar/fonts/font = null
+ProgressBar/styles/bg = SubResource( 7 )
+ProgressBar/styles/fg = null
+RichTextLabel/colors/default_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+RichTextLabel/colors/font_color_selected = Color( 0.490196, 0.490196, 0.490196, 1 )
+RichTextLabel/colors/font_color_shadow = Color( 0, 0, 0, 0 )
+RichTextLabel/colors/selection_color = Color( 0.1, 0.1, 1, 0.8 )
+RichTextLabel/constants/line_separation = 1
+RichTextLabel/constants/shadow_as_outline = 0
+RichTextLabel/constants/shadow_offset_x = 1
+RichTextLabel/constants/shadow_offset_y = 1
+RichTextLabel/constants/table_hseparation = 3
+RichTextLabel/constants/table_vseparation = 3
+RichTextLabel/fonts/bold_font = null
+RichTextLabel/fonts/bold_italics_font = null
+RichTextLabel/fonts/italics_font = null
+RichTextLabel/fonts/mono_font = null
+RichTextLabel/fonts/normal_font = null
+RichTextLabel/styles/focus = null
+RichTextLabel/styles/normal = SubResource( 8 )
+TabContainer/colors/font_color_bg = Color( 0.690196, 0.690196, 0.690196, 1 )
+TabContainer/colors/font_color_disabled = Color( 0.9, 0.9, 0.9, 0.2 )
+TabContainer/colors/font_color_fg = Color( 0.941176, 0.941176, 0.941176, 1 )
+TabContainer/constants/hseparation = 4
+TabContainer/constants/label_valign_bg = 2
+TabContainer/constants/label_valign_fg = 0
+TabContainer/constants/side_margin = 8
+TabContainer/constants/top_margin = 24
+TabContainer/fonts/font = null
+TabContainer/icons/decrement = null
+TabContainer/icons/decrement_highlight = null
+TabContainer/icons/increment = null
+TabContainer/icons/increment_highlight = null
+TabContainer/icons/menu = null
+TabContainer/icons/menu_highlight = null
+TabContainer/styles/panel = null
+TabContainer/styles/tab_bg = SubResource( 9 )
+TabContainer/styles/tab_disabled = SubResource( 10 )
+TabContainer/styles/tab_fg = SubResource( 11 )

--- a/Assets/Interface/Fonts/ExtraInfoDisplayTitledjv_bold.tres
+++ b/Assets/Interface/Fonts/ExtraInfoDisplayTitledjv_bold.tres
@@ -1,0 +1,10 @@
+[gd_resource type="DynamicFont" load_steps=2 format=2]
+
+[ext_resource path="res://Assets/Interface/Fonts/dejavu/DejaVuSans-Bold.ttf" type="DynamicFontData" id=1]
+
+[resource]
+resource_name = "Bold"
+size = 22
+extra_spacing_char = -1
+extra_spacing_space = 1
+font_data = ExtResource( 1 )

--- a/Assets/Interface/StyleBoxes/ExtraInfoDisplayBgPanel.tres
+++ b/Assets/Interface/StyleBoxes/ExtraInfoDisplayBgPanel.tres
@@ -1,0 +1,5 @@
+[gd_resource type="StyleBoxFlat" format=2]
+
+[resource]
+bg_color = Color( 0, 0, 0, 0.607843 )
+border_color = Color( 0.639216, 0.639216, 0.639216, 0.639216 )

--- a/Trees/Interface/ExtraInfoDisplay/ExtraInfoDisplay.gd
+++ b/Trees/Interface/ExtraInfoDisplay/ExtraInfoDisplay.gd
@@ -1,0 +1,37 @@
+"""
+ A popup for text that showcases short but interesting information.
+ Use get_tree().call_group( "ExtraInfoDisplay", "popup", title_text, information_text)
+ to activate it.
+"""
+extends PanelContainer
+
+
+func _input( event : InputEvent ) -> void :
+	#This only starts when popup has been called.
+	#Hide the popup when the player has confirmed they have
+	#read the display.
+	if event.is_action_pressed( "hide_extra_info_display" ) :
+		set_process_input( false )
+		hide()
+		return
+
+func _ready() -> void :
+	#I don't want to process input until after popup has been called.
+	set_process_input( false )
+
+func popup( title_text : String, information_text : String ) -> void :
+	#Make the appropriate nodes have their needed text.
+	$Holder/Title.text = title_text
+	$Holder/Info.text = information_text
+	
+	#Make sure the text detailing what button to press to hide the display is correct.
+	var hide_button_text = "Press "
+	hide_button_text += "'" + OS.get_scancode_string(InputMap.get_action_list("hide_extra_info_display")[0].scancode )
+	hide_button_text += "' to hide this display"
+	$Holder/HideButton.text = hide_button_text
+	
+	#Make the display actually show itself.
+	show()
+	
+	#Start listening for the player to confirm that they read the display.
+	set_process_input( true )

--- a/Trees/Interface/ExtraInfoDisplay/ExtraInfoDisplay.tscn
+++ b/Trees/Interface/ExtraInfoDisplay/ExtraInfoDisplay.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://Assets/Interface/ExtraInfoDisplay.tres" type="Theme" id=1]
+[ext_resource path="res://Assets/Interface/Fonts/ExtraInfoDisplayTitledjv_bold.tres" type="DynamicFont" id=2]
+[ext_resource path="res://Trees/Interface/ExtraInfoDisplay/ExtraInfoDisplay.gd" type="Script" id=3]
+[ext_resource path="res://Assets/Interface/StyleBoxes/ExtraInfoDisplayBgPanel.tres" type="StyleBox" id=4]
+
+[node name="ExtraInfoDisplay" type="PanelContainer" groups=[
+"ExtraInfoDisplay",
+]]
+visible = false
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -600.0
+margin_top = -300.0
+margin_bottom = -70.0
+rect_min_size = Vector2( 250, 120 )
+mouse_filter = 2
+theme = ExtResource( 1 )
+custom_styles/panel = ExtResource( 4 )
+script = ExtResource( 3 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Holder" type="VBoxContainer" parent="."]
+margin_right = 600.0
+margin_bottom = 230.0
+
+[node name="Title" type="Label" parent="Holder"]
+margin_right = 600.0
+margin_bottom = 31.0
+custom_fonts/font = ExtResource( 2 )
+text = "Bonus Info"
+align = 1
+
+[node name="Info" type="RichTextLabel" parent="Holder"]
+margin_top = 35.0
+margin_right = 600.0
+margin_bottom = 201.0
+rect_min_size = Vector2( 0, 100 )
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Hello World. How is everyone doing?
+
+This is a test."
+
+[node name="HideButton" type="Label" parent="Holder"]
+margin_top = 205.0
+margin_right = 600.0
+margin_bottom = 230.0
+text = "If you are seeing this in game something is wrong. ExtraInfoDisplay"

--- a/Trees/Interface/Hud/Hud.tscn
+++ b/Trees/Interface/Hud/Hud.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://Trees/Interface/Hud/Hud.gd" type="Script" id=1]
 [ext_resource path="res://Trees/Interface/Hud/Chat/Chat.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Trees/Interface/Hud/InteractDisplay/InteractDisplay.tscn" type="PackedScene" id=3]
-
+[ext_resource path="res://Trees/Interface/ExtraInfoDisplay/ExtraInfoDisplay.tscn" type="PackedScene" id=4]
 
 [node name="Hud" type="CanvasLayer"]
 layer = 8
@@ -12,3 +12,8 @@ script = ExtResource( 1 )
 [node name="Chat" parent="." instance=ExtResource( 2 )]
 
 [node name="InteractDisplay" parent="." instance=ExtResource( 3 )]
+
+[node name="IgnoreHUDShowCall" type="Node" parent="."]
+
+[node name="ExtraInfoDisplay" parent="IgnoreHUDShowCall" instance=ExtResource( 4 )]
+margin_bottom = -34.0

--- a/project.godot
+++ b/project.godot
@@ -292,6 +292,11 @@ mainmenu_toggle={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
  ]
 }
+hide_extra_info_display={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":52,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [physics]
 


### PR DESCRIPTION
This commit creates ExtraInfoDisplay and all associated resources.
It creates a node in HUD for keeping nodes hidden when HUD's show() is
called. Adds ExtraInfoDisplay.tscn to HUD. The action
hide_extra_info_display has been added to the InputMap via project
settings and has the keyboard key 4 as it's InputEventKey.