### PR TITLE
Main Menu emits signal when start game is pressed.

### DIFF
--- a/Script/Manager/SignalsManager/MenuSignals.gd
+++ b/Script/Manager/SignalsManager/MenuSignals.gd
@@ -1,2 +1,8 @@
 extends Node
 class_name MenuSignals
+
+#Emitted when start game is pressed.
+const START_GAME_PRESSED : String = "start_game_pressed"
+
+#warning-ignore:unused_signal
+signal start_game_pressed()

--- a/Tree/Interface/MainMenu/MainMenu.gd
+++ b/Tree/Interface/MainMenu/MainMenu.gd
@@ -30,7 +30,7 @@ func _on_bQuit_pressed() -> void:
 
 func _on_bStart_pressed() -> void:
 	#This is a temporary button with temporary code.
-	return
+	Signals.Menus.emit_signal(Signals.Menus.START_GAME_PRESSED)
 #	var test_scene = preload("res://_tests/NewDemo/TestScene.tscn")
 #	get_tree().change_scene_to(test_scene)
 #	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)

--- a/Tree/Interface/MainMenu/MainMenu.tscn
+++ b/Tree/Interface/MainMenu/MainMenu.tscn
@@ -114,7 +114,6 @@ theme = ExtResource( 8 )
 custom_fonts/font = ExtResource( 7 )
 text = "Quit"
 [connection signal="pressed" from="Bottom/bStart" to="." method="_on_bStart_pressed"]
-[connection signal="pressed" from="Bottom/bJoinServer" to="." method="_on_bJoinServer_pressed"]
 [connection signal="pressed" from="Bottom/bLocalGame" to="." method="_on_bLocalGame_pressed"]
 [connection signal="pressed" from="Bottom/bAbout" to="." method="_on_bAbout_pressed"]
 [connection signal="pressed" from="Bottom/bQuit" to="." method="_on_bQuit_pressed"]


### PR DESCRIPTION
Super small PR that adds a emit_signal call so listening nodes know menu has clicked on start game.