### PR TITLE
Add overhauled menus

### DIFF
--- a/Tree/Interface/MainMenu/MainMenu.tscn
+++ b/Tree/Interface/MainMenu/MainMenu.tscn
@@ -150,6 +150,7 @@ focus_neighbour_top = NodePath("../Avatar")
 focus_neighbour_right = NodePath("../../../About")
 focus_neighbour_bottom = NodePath("../Apps")
 size_flags_horizontal = 0
+disabled = true
 text = "  Controls  "
 __meta__ = {
 "_edit_use_anchors_": false
@@ -164,6 +165,7 @@ focus_neighbour_top = NodePath("../Controls")
 focus_neighbour_right = NodePath("../../../About")
 focus_neighbour_bottom = NodePath("../Display")
 size_flags_horizontal = 0
+disabled = true
 text = "  Apps  "
 __meta__ = {
 "_edit_use_anchors_": false
@@ -178,6 +180,7 @@ focus_neighbour_top = NodePath("../Apps")
 focus_neighbour_right = NodePath("../../../About")
 focus_neighbour_bottom = NodePath("../Destination")
 size_flags_horizontal = 0
+disabled = true
 text = "  Display  "
 __meta__ = {
 "_edit_use_anchors_": false


### PR DESCRIPTION
- Main Menu theme now in line with concept art
- Added gfx to main menu buttons.
- Main Menu emits signal when start game is pressed.
- Script made for button gfx to adhere to SRP.
- Add improved Moonwards logo to project.
- Focus neighbors now navigable.
- Add updated logo in svg and png.
- Grey out MainMenu buttons.

Addresses issue #268