### PR TITLE
AudioSphere uses Signals manager

### DIFF
--- a/SceneComponent/Utilities/AudioTour/AudioSphere.gd
+++ b/SceneComponent/Utilities/AudioTour/AudioSphere.gd
@@ -8,16 +8,26 @@ export var audio_file : AudioStreamOGGVorbis = AudioStreamOGGVorbis.new()
 
 
 func _ready() -> void :
+	#Will crash if no file is given to the AudioSphere.
+	assert(audio_file.resource_path != "")
+	
 	audio_file.loop = false
 	$Audio.stream = audio_file
 
-
 #warning-ignore:unused_argument
-func play_sound(interactor_ray_cast):
+func _play_sound(interactor_ray_cast):
 	#Player requested audio. Play the audio.
-	get_tree().call_group( "SoloAudioPlayer", "stop" )
+	Signals.Audio.emit_signal(Signals.Audio.SOLO_AUDIO_STREAM_BEGUN)
 	$Audio.play()
+	
+	#Start listening for other solo audio players to play.
+	Signals.Audio.connect(Signals.Audio.SOLO_AUDIO_STREAM_BEGUN, self, "_stop")
 
-
-func stop() -> void :
+func _stop() -> void :
+	Signals.Audio.disconnect(Signals.Audio.SOLO_AUDIO_STREAM_BEGUN, self, "_stop")
+	
+	#Stop playing.
 	$Audio.stop()
+	
+	#Let Signals know that I have ended.
+	Signals.Audio.emit_signal(Signals.Audio.SOLO_AUDIO_STREAM_ENDED)

--- a/SceneComponent/Utilities/AudioTour/AudioSphere.tscn
+++ b/SceneComponent/Utilities/AudioTour/AudioSphere.tscn
@@ -4,17 +4,10 @@
 [ext_resource path="res://SceneComponent/Utilities/Interactable/Interactable.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Assets/MoonTown/Models/Audio_Tour_Markers/Audio_Tour_intro.ogg" type="AudioStream" id=3]
 
-
-
-
-
-
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 0.05, 0.05, 0.05 )
 
-[node name="AudioSphere" groups=[
-"SoloAudioPlayer",
-] instance=ExtResource( 2 )]
+[node name="AudioSphere" instance=ExtResource( 2 )]
 script = ExtResource( 1 )
 display_info = "play audio recording"
 
@@ -23,4 +16,5 @@ stream = ExtResource( 3 )
 
 [node name="CollisionShape" type="CollisionShape" parent="." index="1"]
 shape = SubResource( 1 )
-[connection signal="interacted_with" from="." to="." method="play_sound"]
+[connection signal="interacted_with" from="." to="." method="_play_sound"]
+[connection signal="finished" from="Audio" to="." method="_stop"]

--- a/Script/Manager/SignalsManager/AudioSignals.gd
+++ b/Script/Manager/SignalsManager/AudioSignals.gd
@@ -1,0 +1,12 @@
+extends Node
+class_name AudioSignals
+
+#This signal is emiited when an audio player that is meant to be
+#playing by itself with no other solo audio player has started.
+const SOLO_AUDIO_STREAM_BEGUN : String = "solo_audio_stream_begun"
+const SOLO_AUDIO_STREAM_ENDED : String = "solo_audio_stream_ended"
+# Define the actual signal.
+#warning-ignore:unused_signal
+signal solo_audio_stream_begun()
+#warning-ignore:unused_signal
+signal solo_audio_stream_ended()

--- a/Script/Manager/SignalsManager/SignalsManager.gd
+++ b/Script/Manager/SignalsManager/SignalsManager.gd
@@ -17,6 +17,8 @@ var Menus = MenuSignals.new() setget _set_illegal
 var Hud = HudSignals.new() setget _set_illegal
 var Network = NetworkSignals.new() setget _set_illegal
 var Lod = LodSignals.new() setget _set_illegal
+var Audio = AudioSignals.new() setget _set_illegal
+
 # These are constant instances and should not be set at all.
 func _set_illegal(_val) -> void:
 	Log.warning(self, "_set_illegal","Set invocation is illegal")


### PR DESCRIPTION
- AudioSphere abides by Godot code guidelines.
- AudioSphere has more logical way of stopping other solo audio players.
- Follows code style guidelines.
- AudioSphere enforces audio files be present.

Resolves issue #321 