### PR TITLE
Feat/logger

### DIFF
--- a/Assets/Interface/LoggerConsoleTheme.tres
+++ b/Assets/Interface/LoggerConsoleTheme.tres
@@ -1,0 +1,145 @@
+[gd_resource type="Theme" load_steps=17 format=2]
+
+[ext_resource path="res://Assets/Interface/Fonts/MainMenuFont.tres" type="DynamicFont" id=1]
+[ext_resource path="res://Assets/Interface/StyleBoxes/ChatPanelRichTextLabel.tres" type="StyleBox" id=2]
+[ext_resource path="res://Assets/Interface/StyleBoxes/ChatLineEdit.tres" type="StyleBox" id=3]
+[ext_resource path="res://Assets/Interface/StyleBoxes/MainMenuFocusStyle.tres" type="StyleBox" id=4]
+[ext_resource path="res://Assets/Interface/StyleBoxes/ChatDisabledLineEdit.tres" type="StyleBox" id=5]
+[ext_resource path="res://Assets/Interface/Fonts/ChatFont.tres" type="DynamicFont" id=6]
+
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0, 0, 0, 0.392157 )
+
+[sub_resource type="StyleBoxFlat" id=2]
+bg_color = Color( 0, 0, 0, 0.607843 )
+
+[sub_resource type="StyleBoxFlat" id=3]
+content_margin_left = 10.0
+content_margin_right = 10.0
+content_margin_top = 10.0
+content_margin_bottom = 10.0
+bg_color = Color( 0.120504, 0.120504, 0.120504, 0.588235 )
+
+[sub_resource type="StyleBoxEmpty" id=4]
+
+[sub_resource type="StyleBoxFlat" id=5]
+content_margin_left = 10.0
+content_margin_right = 10.0
+bg_color = Color( 0, 0, 0, 0.588235 )
+
+[sub_resource type="StyleBoxFlat" id=6]
+bg_color = Color( 0, 0, 0, 0.392157 )
+
+[sub_resource type="StyleBoxFlat" id=7]
+bg_color = Color( 0, 0, 0, 0.607843 )
+
+[sub_resource type="StyleBoxFlat" id=8]
+content_margin_left = 10.0
+content_margin_right = 10.0
+content_margin_top = 10.0
+content_margin_bottom = 10.0
+bg_color = Color( 0.120504, 0.120504, 0.120504, 0.588235 )
+
+[sub_resource type="StyleBoxEmpty" id=9]
+
+[sub_resource type="StyleBoxFlat" id=10]
+content_margin_left = 10.0
+content_margin_right = 10.0
+bg_color = Color( 0, 0, 0, 0.588235 )
+
+[resource]
+default_font = ExtResource( 6 )
+Button/colors/font_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+Button/colors/font_color_disabled = Color( 0.9, 0.9, 0.9, 0.2 )
+Button/colors/font_color_hover = Color( 0.941176, 0.941176, 0.941176, 1 )
+Button/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+Button/constants/hseparation = 20
+Button/fonts/font = ExtResource( 1 )
+Button/styles/disabled = SubResource( 1 )
+Button/styles/focus = ExtResource( 4 )
+Button/styles/hover = ExtResource( 4 )
+Button/styles/normal = SubResource( 2 )
+Button/styles/pressed = null
+Label/colors/font_color = Color( 1, 1, 1, 1 )
+Label/colors/font_color_shadow = Color( 0, 0, 0, 0 )
+Label/colors/font_outline_modulate = Color( 1, 1, 1, 1 )
+Label/constants/line_spacing = 3
+Label/constants/shadow_as_outline = 0
+Label/constants/shadow_offset_x = 1
+Label/constants/shadow_offset_y = 1
+Label/fonts/font = null
+Label/styles/normal = SubResource( 3 )
+LineEdit/colors/clear_button_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+LineEdit/colors/clear_button_color_pressed = Color( 1, 1, 1, 1 )
+LineEdit/colors/cursor_color = Color( 0.941176, 0.941176, 0.941176, 1 )
+LineEdit/colors/font_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+LineEdit/colors/font_color_selected = Color( 0, 0, 0, 1 )
+LineEdit/colors/selection_color = Color( 0.490196, 0.490196, 0.490196, 1 )
+LineEdit/constants/minimum_spaces = 12
+LineEdit/fonts/font = null
+LineEdit/icons/clear = null
+LineEdit/styles/focus = ExtResource( 3 )
+LineEdit/styles/normal = ExtResource( 3 )
+LineEdit/styles/read_only = ExtResource( 5 )
+Panel/styles/panel = ExtResource( 2 )
+Panel/styles/panelf = ExtResource( 2 )
+Panel/styles/panelnc = ExtResource( 2 )
+PopupMenu/colors/font_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+PopupMenu/colors/font_color_accel = Color( 0.7, 0.7, 0.7, 0.8 )
+PopupMenu/colors/font_color_disabled = Color( 0.4, 0.4, 0.4, 0.8 )
+PopupMenu/colors/font_color_hover = Color( 0.878431, 0.878431, 0.878431, 1 )
+PopupMenu/constants/hseparation = 4
+PopupMenu/constants/vseparation = 4
+PopupMenu/fonts/font = null
+PopupMenu/icons/checked = null
+PopupMenu/icons/radio_checked = null
+PopupMenu/icons/radio_unchecked = null
+PopupMenu/icons/submenu = null
+PopupMenu/icons/unchecked = null
+PopupMenu/styles/hover = null
+PopupMenu/styles/labeled_separator_left = null
+PopupMenu/styles/labeled_separator_right = null
+PopupMenu/styles/panel = SubResource( 4 )
+PopupMenu/styles/panel_disabled = null
+PopupMenu/styles/separator = null
+ProgressBar/colors/font_color = Color( 0.941176, 0.941176, 0.941176, 1 )
+ProgressBar/colors/font_color_shadow = Color( 0, 0, 0, 1 )
+ProgressBar/fonts/font = null
+ProgressBar/styles/bg = SubResource( 5 )
+ProgressBar/styles/fg = null
+RichTextLabel/colors/default_color = Color( 0.878431, 0.878431, 0.878431, 1 )
+RichTextLabel/colors/font_color_selected = Color( 0.490196, 0.490196, 0.490196, 1 )
+RichTextLabel/colors/font_color_shadow = Color( 0, 0, 0, 0 )
+RichTextLabel/colors/selection_color = Color( 0.1, 0.1, 1, 0.8 )
+RichTextLabel/constants/line_separation = 1
+RichTextLabel/constants/shadow_as_outline = 0
+RichTextLabel/constants/shadow_offset_x = 1
+RichTextLabel/constants/shadow_offset_y = 1
+RichTextLabel/constants/table_hseparation = 3
+RichTextLabel/constants/table_vseparation = 3
+RichTextLabel/fonts/bold_font = null
+RichTextLabel/fonts/bold_italics_font = null
+RichTextLabel/fonts/italics_font = null
+RichTextLabel/fonts/mono_font = null
+RichTextLabel/fonts/normal_font = null
+RichTextLabel/styles/focus = null
+RichTextLabel/styles/normal = SubResource( 6 )
+TabContainer/colors/font_color_bg = Color( 0.690196, 0.690196, 0.690196, 1 )
+TabContainer/colors/font_color_disabled = Color( 0.9, 0.9, 0.9, 0.2 )
+TabContainer/colors/font_color_fg = Color( 0.941176, 0.941176, 0.941176, 1 )
+TabContainer/constants/hseparation = 4
+TabContainer/constants/label_valign_bg = 2
+TabContainer/constants/label_valign_fg = 0
+TabContainer/constants/side_margin = 8
+TabContainer/constants/top_margin = 24
+TabContainer/fonts/font = null
+TabContainer/icons/decrement = null
+TabContainer/icons/decrement_highlight = null
+TabContainer/icons/increment = null
+TabContainer/icons/increment_highlight = null
+TabContainer/icons/menu = null
+TabContainer/icons/menu_highlight = null
+TabContainer/styles/panel = SubResource( 7 )
+TabContainer/styles/tab_bg = SubResource( 8 )
+TabContainer/styles/tab_disabled = SubResource( 9 )
+TabContainer/styles/tab_fg = SubResource( 10 )

--- a/SceneComponent/Interface/LoggerConsole/LoggerConsole.gd
+++ b/SceneComponent/Interface/LoggerConsole/LoggerConsole.gd
@@ -10,3 +10,12 @@ func _input(event: InputEvent) -> void:
 		var visible_status : bool = !get_child(0).visible
 		for child in get_children() :
 			child.visible = visible_status
+
+
+func _filter_toggled(_button_pressed):
+	var trace = get_node("Container/Filters/Trace").pressed
+	var debug = get_node("Container/Filters/Debug").pressed
+	var warning =  get_node("Container/Filters/Warning").pressed
+	var error =  get_node("Container/Filters/Error").pressed
+	var critical =  get_node("Container/Filters/Critical").pressed
+	get_node("Container/LoggerText").filter_text(trace, debug, warning, error, critical)

--- a/SceneComponent/Interface/LoggerConsole/LoggerConsole.gd
+++ b/SceneComponent/Interface/LoggerConsole/LoggerConsole.gd
@@ -1,0 +1,12 @@
+extends CanvasLayer
+
+func _ready() -> void :
+	$Panel.anchor_right = $Container.anchor_right
+	$Panel.anchor_bottom = $Container.anchor_bottom
+
+func _input(event: InputEvent) -> void:
+	#Toggle whether I am visible or not.
+	if event.is_action_pressed("toggle_logger"):
+		var visible_status : bool = !get_child(0).visible
+		for child in get_children() :
+			child.visible = visible_status

--- a/SceneComponent/Interface/LoggerConsole/LoggerConsole.tscn
+++ b/SceneComponent/Interface/LoggerConsole/LoggerConsole.tscn
@@ -23,7 +23,7 @@ __meta__ = {
 
 [node name="LoggerText" type="RichTextLabel" parent="Container"]
 margin_right = 1920.0
-margin_bottom = 324.0
+margin_bottom = 296.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 3 )
@@ -31,3 +31,52 @@ bbcode_enabled = true
 bbcode_text = "This is fun."
 scroll_following = true
 script = ExtResource( 2 )
+
+[node name="Filters" type="HBoxContainer" parent="Container"]
+margin_top = 300.0
+margin_right = 1920.0
+margin_bottom = 324.0
+alignment = 2
+
+[node name="Label" type="Label" parent="Container/Filters"]
+margin_left = 1507.0
+margin_top = 5.0
+margin_right = 1559.0
+margin_bottom = 19.0
+text = "FILTERS:"
+
+[node name="Trace" type="CheckBox" parent="Container/Filters"]
+margin_left = 1563.0
+margin_right = 1625.0
+margin_bottom = 24.0
+pressed = true
+text = "Trace"
+
+[node name="Debug" type="CheckBox" parent="Container/Filters"]
+margin_left = 1629.0
+margin_right = 1698.0
+margin_bottom = 24.0
+pressed = true
+text = "Debug"
+
+[node name="Warning" type="CheckBox" parent="Container/Filters"]
+margin_left = 1702.0
+margin_right = 1782.0
+margin_bottom = 24.0
+pressed = true
+text = "Warning"
+
+[node name="Error" type="CheckBox" parent="Container/Filters"]
+margin_left = 1786.0
+margin_right = 1844.0
+margin_bottom = 24.0
+pressed = true
+text = "Error"
+
+[node name="Critical" type="CheckBox" parent="Container/Filters"]
+margin_left = 1848.0
+margin_right = 1920.0
+margin_bottom = 24.0
+pressed = true
+text = "Critical"
+[connection signal="toggled" from="Container/Filters/Trace" to="." method="_filter_toggled"]

--- a/SceneComponent/Interface/LoggerConsole/LoggerConsole.tscn
+++ b/SceneComponent/Interface/LoggerConsole/LoggerConsole.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://SceneComponent/Interface/LoggerConsole/LoggerConsole.gd" type="Script" id=1]
+[ext_resource path="res://SceneComponent/Interface/LoggerConsole/LoggerText.gd" type="Script" id=2]
+[ext_resource path="res://Assets/Interface/LoggerConsoleTheme.tres" type="Theme" id=3]
+
+[node name="LoggerConsole" type="CanvasLayer"]
+layer = -128
+script = ExtResource( 1 )
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Container" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 0.3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LoggerText" type="RichTextLabel" parent="Container"]
+margin_right = 1920.0
+margin_bottom = 324.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme = ExtResource( 3 )
+bbcode_enabled = true
+bbcode_text = "This is fun."
+scroll_following = true
+script = ExtResource( 2 )

--- a/SceneComponent/Interface/LoggerConsole/LoggerText.gd
+++ b/SceneComponent/Interface/LoggerConsole/LoggerText.gd
@@ -1,11 +1,20 @@
 extends RichTextLabel
 
 
-var unfiltered_text : String = ""
+const TRACE = 0
+const DEBUG = 1
+const WARNING = 2
+const ERROR = 4
+const CRITICAL = 8
 
-func _add_text(message : String) -> void :
-	unfiltered_text += "\n"
-	unfiltered_text += message
+
+var trace_text : PoolStringArray = PoolStringArray()
+var debug_text : PoolStringArray = PoolStringArray()
+var warning_text : PoolStringArray = PoolStringArray()
+var error_text : PoolStringArray = PoolStringArray()
+var critical_text : PoolStringArray = PoolStringArray()
+
+var message_type_history : Array = []
 
 func _filter_text(message : String) -> String :
 	message = message.right(message.find("]", 0) + 1)
@@ -18,30 +27,35 @@ func _on_trace_logged(message) -> void:
 	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += message
-	_add_text(message)
+	trace_text.append("\n" + message)
+	message_type_history.append(TRACE)
 
 func _on_debug_logged(message) -> void:
 	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=#03fc8c]" + message + "[/color]"
-	_add_text("[color=#03fc8c]" + message + "[/color]")
+	debug_text.append("\n" + message)
+	message_type_history.append(DEBUG)
 
 func _on_warning_logged(message) -> void:
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=yellow]" + message + "[/color]"
-	_add_text("[color=yellow]" + message + "[/color]")
+	warning_text.append("\n" + message)
+	message_type_history.append(WARNING)
 
 func _on_error_logged(message) -> void:
 	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=#fc5603]" + message + "[/color]"
-	_add_text("[color=#fc5603]" + message + "[/color]")
+	error_text.append("\n" + message)
+	message_type_history.append(ERROR)
 
 func _on_critical_logged(message) -> void:
 	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=red]" + message + "[/color]"
-	_add_text("[color=red]" + message + "[/color]")
+	critical_text.append("\n" + message)
+	message_type_history.append(CRITICAL)
 
 func deferred_ready() -> void :
 	var logger : Node = get_parent().get_parent().get_parent()
@@ -58,6 +72,45 @@ func deferred_ready() -> void :
 #Filter out messages from levels you do not care about.
 func filter_text(trace : bool, debug : bool, warning : bool,
 					error : bool, critical : bool) -> void :
-	pass
+	bbcode_text = ""
+					
+	#Setup an Array for determine which messages to
+	#let through.
+	var unfiltered_message_types : Array = []
+	if trace: unfiltered_message_types.append(TRACE)
+	if debug: unfiltered_message_types.append(DEBUG)
+	if warning: unfiltered_message_types.append(WARNING)
+	if error: unfiltered_message_types.append(ERROR)
+	if critical: unfiltered_message_types.append(CRITICAL)
+	
+	#These are for placing in the relevant unfiltered messages.
+	var trace_at : int = 0
+	var debug_at : int = 0
+	var warning_at : int = 0
+	var error_at : int = 0
+	var critical_at : int = 0
+	
+	#Go through history and check if the message should be filtered
+	#or not.
+	for type in message_type_history :
+		if unfiltered_message_types.has(type) :
+			
+			#We are an allowed message. Add to LoggerText output
+			if type == TRACE && not trace_text.empty() :
+				bbcode_text += trace_text[trace_at]
+				trace_at += 1
+			elif type == DEBUG && not debug_text.empty() :
+				bbcode_text += debug_text[debug_at]
+				debug_at += 1
+			elif type == WARNING && not warning_text.empty() :
+				bbcode_text += warning_text[warning_at]
+				warning_at += 1
+			elif type == ERROR && not error_text.empty() :
+				bbcode_text += error_text[error_at]
+				error_at += 1
+			elif type == CRITICAL && not critical_text.empty() :
+				bbcode_text += critical_text[critical_at]
+				critical_at += 1
+				
 	
 

--- a/SceneComponent/Interface/LoggerConsole/LoggerText.gd
+++ b/SceneComponent/Interface/LoggerConsole/LoggerText.gd
@@ -1,0 +1,40 @@
+extends RichTextLabel
+
+
+func _ready() -> void :
+	call_deferred("deferred_ready")
+
+func _on_trace_logged(message) -> void:
+	bbcode_text += "\n" # new_line uses buggy append_bbcode func
+	bbcode_text += message
+
+func _on_debug_logged(message) -> void:
+	bbcode_text += "\n" # new_line uses buggy append_bbcode func
+	bbcode_text += "[color=#03fc8c]" + message + "[/color]"
+
+func _on_warning_logged(message) -> void:
+	bbcode_text += "\n" # new_line uses buggy append_bbcode func
+	bbcode_text += "[color=yellow]" + message + "[/color]"
+
+func _on_error_logged(message) -> void:
+	bbcode_text += "\n" # new_line uses buggy append_bbcode func
+	bbcode_text += "[color=#fc5603]" + message + "[/color]"
+
+func _on_critical_logged(message) -> void:
+	bbcode_text += "\n" # new_line uses buggy append_bbcode func
+	bbcode_text += "[color=red]" + message + "[/color]"
+
+func deferred_ready() -> void :
+	var logger : Node = get_parent().get_parent().get_parent()
+	logger.connect("trace_logged", self, "_on_trace_logged")
+	# warning-ignore:return_value_discarded
+	logger.connect("debug_logged", self, "_on_debug_logged")
+	# warning-ignore:return_value_discarded
+	logger.connect("warning_logged", self, "_on_warning_logged")
+	# warning-ignore:return_value_discarded
+	logger.connect("error_logged", self, "_on_error_logged")
+	# warning-ignore:return_value_discarded
+	logger.connect("critical_logged", self, "_on_critical_logged")
+
+
+

--- a/SceneComponent/Interface/LoggerConsole/LoggerText.gd
+++ b/SceneComponent/Interface/LoggerConsole/LoggerText.gd
@@ -1,28 +1,47 @@
 extends RichTextLabel
 
 
+var unfiltered_text : String = ""
+
+func _add_text(message : String) -> void :
+	unfiltered_text += "\n"
+	unfiltered_text += message
+
+func _filter_text(message : String) -> String :
+	message = message.right(message.find("]", 0) + 1)
+	return message
+
 func _ready() -> void :
 	call_deferred("deferred_ready")
 
 func _on_trace_logged(message) -> void:
+	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += message
+	_add_text(message)
 
 func _on_debug_logged(message) -> void:
+	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=#03fc8c]" + message + "[/color]"
+	_add_text("[color=#03fc8c]" + message + "[/color]")
 
 func _on_warning_logged(message) -> void:
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=yellow]" + message + "[/color]"
+	_add_text("[color=yellow]" + message + "[/color]")
 
 func _on_error_logged(message) -> void:
+	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=#fc5603]" + message + "[/color]"
+	_add_text("[color=#fc5603]" + message + "[/color]")
 
 func _on_critical_logged(message) -> void:
+	message = _filter_text(message)
 	bbcode_text += "\n" # new_line uses buggy append_bbcode func
 	bbcode_text += "[color=red]" + message + "[/color]"
+	_add_text("[color=red]" + message + "[/color]")
 
 func deferred_ready() -> void :
 	var logger : Node = get_parent().get_parent().get_parent()
@@ -36,5 +55,9 @@ func deferred_ready() -> void :
 	# warning-ignore:return_value_discarded
 	logger.connect("critical_logged", self, "_on_critical_logged")
 
-
+#Filter out messages from levels you do not care about.
+func filter_text(trace : bool, debug : bool, warning : bool,
+					error : bool, critical : bool) -> void :
+	pass
+	
 

--- a/Script/Manager/Logger.gd
+++ b/Script/Manager/Logger.gd
@@ -56,10 +56,7 @@ var console_canvas_layer: int = 10 # What canvas layer to place the label on
 
 func _ready() -> void:
 	if use_builtin_console:
-		var n: CanvasLayer = CanvasLayer.new()
-		add_child(n)
-		n.layer = console_canvas_layer
-		n.add_child(LoggerConsole.new(self))
+		pass
 
 
 func error_to_string(code : int) -> String:
@@ -165,61 +162,3 @@ func _get_time_string() -> String:
 	var s: String = "%4d-%02d-%02d %02d:%02d:%02d" % [dt.year, dt.month, dt.day, 
 		dt.hour,dt.minute,dt.second]
 	return s
-
-
-class LoggerConsole:
-	extends RichTextLabel
-	
-	
-	func _init(creator: Node) -> void:
-		# Control
-		visible = false
-		set_anchors_and_margins_preset(Control.PRESET_WIDE)
-		focus_mode = Control.FOCUS_NONE
-		mouse_filter = Control.MOUSE_FILTER_PASS
-		
-		# RichTextLabel
-		scroll_following = true
-		scroll_active = false
-		bbcode_enabled = true
-		
-		# warning-ignore:return_value_discarded
-		creator.connect("trace_logged", self, "_on_trace_logged")
-		# warning-ignore:return_value_discarded
-		creator.connect("debug_logged", self, "_on_debug_logged")
-		# warning-ignore:return_value_discarded
-		creator.connect("warning_logged", self, "_on_warning_logged")
-		# warning-ignore:return_value_discarded
-		creator.connect("error_logged", self, "_on_error_logged")
-		# warning-ignore:return_value_discarded
-		creator.connect("critical_logged", self, "_on_critical_logged")
-	
-	
-	func _input(event: InputEvent) -> void:
-		if event.is_action_pressed("toggle_logger"):
-			visible = !visible
-	
-	
-	func _on_trace_logged(message) -> void:
-		bbcode_text += "\n" # new_line uses buggy append_bbcode func
-		bbcode_text += message
-	
-	
-	func _on_debug_logged(message) -> void:
-		bbcode_text += "\n" # new_line uses buggy append_bbcode func
-		bbcode_text += "[color=#03fc8c]" + message + "[/color]"
-	
-	
-	func _on_warning_logged(message) -> void:
-		bbcode_text += "\n" # new_line uses buggy append_bbcode func
-		bbcode_text += "[color=yellow]" + message + "[/color]"
-	
-	
-	func _on_error_logged(message) -> void:
-		bbcode_text += "\n" # new_line uses buggy append_bbcode func
-		bbcode_text += "[color=#fc5603]" + message + "[/color]"
-	
-	
-	func _on_critical_logged(message) -> void:
-		bbcode_text += "\n" # new_line uses buggy append_bbcode func
-		bbcode_text += "[color=red]" + message + "[/color]"

--- a/Tree/Manager/Log.tscn
+++ b/Tree/Manager/Log.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Script/Manager/Logger.gd" type="Script" id=1]
+[ext_resource path="res://SceneComponent/Interface/LoggerConsole/LoggerConsole.tscn" type="PackedScene" id=2]
+
+[node name="Log" type="Node"]
+script = ExtResource( 1 )
+
+[node name="LoggerConsole" parent="." instance=ExtResource( 2 )]

--- a/project.godot
+++ b/project.godot
@@ -171,7 +171,7 @@ config/icon="res://icon.png"
 [autoload]
 
 WorldConstants="*res://Script/Manager/WorldConstants.gd"
-Log="*res://Script/Manager/Logger.gd"
+Log="*res://Tree/Manager/Log.tscn"
 Helpers="*res://Script/Manager/Helpers.gd"
 CmdLineArgs="*res://Script/Manager/CmdLineArgs.gd"
 Signals="*res://Script/Manager/SignalsManager/SignalsManager.gd"


### PR DESCRIPTION
I had to change the Autoloaded logger into a scene that gets autoloaded. If this is unwanted, I can change it back to autoloading a script.
I kept Logger.gd in Scripts/Managers and placed Log.tscn (the autoloaded scene with Logger.gd as it's script) in Trees/Managers.

The reason for this is that adding classes as children do not allow you to use a full scene. Forcing you into making everything instance through code. This is very offputting to newcomers to Moonwards development imo. I chose this strategy as Godot likes to load scenes as Autoloaded Singletons.

Resolves issue #382 