### PR TITLE
Interactor can interact with closest interactable

### DIFF
--- a/SceneComponent/Actor/InteractorComponent.gd
+++ b/SceneComponent/Actor/InteractorComponent.gd
@@ -22,6 +22,13 @@ export var grab_focus_at_ready : bool = true
 func _init().("Interactor", true) -> void :
 	pass
 
+#Check for when the player wants to interact with the closest interactable.
+func _input(event : InputEvent) -> void :
+	if event.is_action_pressed("interact_with_closest") :
+		var interactable = interactor.get_closest_interactable()
+		if interactable != null :
+			on_interact_menu_request(interactable)
+
 #Make Interactor have my Entity variable as it's user.
 func _ready() -> void :
 	interactor.owning_entity = self.entity

--- a/SceneComponent/Actor/InteractorComponent.gd
+++ b/SceneComponent/Actor/InteractorComponent.gd
@@ -29,6 +29,9 @@ func _input(event : InputEvent) -> void :
 		if interactable != null :
 			on_interact_menu_request(interactable)
 
+func _make_hud_display_interactable(interactable : Interactable = null) -> void :
+	Signals.Hud.emit_signal(Signals.Hud.CLOSEST_INTERACTABLE_CHANGED, interactable)
+
 #Make Interactor have my Entity variable as it's user.
 func _ready() -> void :
 	interactor.owning_entity = self.entity
@@ -37,6 +40,9 @@ func _ready() -> void :
 	interactor.connect("interact_made_possible", self, "relay_signal", [INTERACT_MADE_POSSIBLE])
 	interactor.connect("interactable_entered_area", self, "relay_signal", [INTERACTABLE_ENTERED_REACH])
 	interactor.connect("interactable_left_area", self, "relay_signal", [INTERACTABLE_LEFT_REACH])
+	
+	#Display what is the closest interactable.
+	interactor.connect("closest_interactable_changed", self, "_make_hud_display_interactable")
 	
 	# call_deferred("_ready_deferred")
 

--- a/Script/GameLogic/Interact/Interactor/Interactor.gd
+++ b/Script/GameLogic/Interact/Interactor/Interactor.gd
@@ -8,6 +8,9 @@ class_name Interactor
 #This is what I pass as the interactor.
 var owning_entity : AEntity
 
+#This is the closest interactable at any given moment.
+var closest_interactable : Interactable
+
 var enabled: bool setget set_enabled
 
 signal interactable_entered_area(interactable_node)
@@ -55,6 +58,7 @@ func _physics_process(_delta : float) -> void:
 			emit_signal("interact_made_impossible")
 		interactables = []
 		previous_collider = null
+		closest_interactable = null
 		return
 	
 	#Return the interactable's name and notify listener's of it.
@@ -62,6 +66,11 @@ func _physics_process(_delta : float) -> void:
 		var interact_info : String = closest_body.get_info()
 		emit_signal("interact_made_possible", interact_info)
 		previous_collider = closest_body
+		closest_interactable = closest_body
+
+#Returns null if there is no Interactable.
+func get_closest_interactable() -> Interactable :
+	return closest_interactable
 
 #Return what interactables can be interacted with
 func get_potential_interacts() -> Array :

--- a/Script/GameLogic/Interact/Interactor/Interactor.gd
+++ b/Script/GameLogic/Interact/Interactor/Interactor.gd
@@ -13,6 +13,8 @@ var closest_interactable : Interactable
 
 var enabled: bool setget set_enabled
 
+#The closest interactable has changed.
+signal closest_interactable_changed(interactable)
 signal interactable_entered_area(interactable_node)
 signal interactable_left_area(interactable_node)
 signal interact_made_possible(string_closest_potential_interact)
@@ -56,6 +58,7 @@ func _physics_process(_delta : float) -> void:
 		#emit a signal saying that.
 		if previous_collider != null :
 			emit_signal("interact_made_impossible")
+			emit_signal("closest_interactable_changed", null)
 		interactables = []
 		previous_collider = null
 		closest_interactable = null
@@ -65,6 +68,7 @@ func _physics_process(_delta : float) -> void:
 	if previous_collider != closest_body :
 		var interact_info : String = closest_body.get_info()
 		emit_signal("interact_made_possible", interact_info)
+		emit_signal("closest_interactable_changed", closest_body)
 		previous_collider = closest_body
 		closest_interactable = closest_body
 

--- a/Script/Manager/SignalsManager/HudSignals.gd
+++ b/Script/Manager/SignalsManager/HudSignals.gd
@@ -7,31 +7,27 @@ const name = "Hud"
 # Define the signal's string name.
 const CHAT_TYPING_STARTED : String = "chat_typing"
 const CHAT_TYPING_FINISHED : String = "chat_finished_typing"
+const CLOSEST_INTERACTABLE_CHANGED : String = "closest_interactable_changed"
 const EXTRA_INFO_DISPLAYED : String = "extra_info_displayed"
 const HIDDEN_HUDS_SET : String = "hidden_huds_set"
 const HIDE_INTERACTS_MENU_REQUESTED: String = "hide_interacts_menu_requested"
 const INTERACTABLE_ENTERED_REACH : String = "interactable_entered_reach"
 const INTERACTABLE_LEFT_REACH : String = "interactable_left_reach"
-const INTERACT_POSSIBLE : String = "interact_possible"
-const INTERACT_BECAME_IMPOSSIBLE : String = "interact_became_impossible"
 const INTERACT_OCCURED : String = "interact_occured"
 const NEW_INTERACTOR_GRABBED_FOCUS : String = "new_interactor_grabbed_focus"
-const POTENTIAL_INTERACT_REQUESTED : String = "potential_interact_requested"
 const VISIBLE_HUDS_SET : String = "visible_huds_set"
 
 # Define the actual signal.
 #warning-ignore:unused_signal
 signal chat_finished_typing()
 signal chat_typing()
+signal closest_interactable_changed(interactable)
 #warning-ignore:unused_signal
 signal extra_info_displayed(title_text, info_text)
 signal hidden_huds_set(hide_flag_int)
 signal hide_interacts_menu_requested()
 signal interactable_entered_reach(interactable_node)
 signal interactable_left_reach(interactable_node)
-signal interact_possible(interaction_info_string)
-signal interact_became_impossible()
 signal interact_occured(interactable_user_node)
 signal new_interactor_grabbed_focus(new_interactor_component_node)
-signal potential_interact_requested(potential_interact_array)
 signal visible_huds_set(show_flag_int)

--- a/Tree/Interface/Hud/InteractDisplay/InteractDisplay.gd
+++ b/Tree/Interface/Hud/InteractDisplay/InteractDisplay.gd
@@ -4,15 +4,18 @@ extends Label
 """
 
 func _ready() -> void :
-	Signals.Hud.connect(Signals.Hud.INTERACT_POSSIBLE, self, "show_interact_info")
-	Signals.Hud.connect(Signals.Hud.INTERACT_BECAME_IMPOSSIBLE, self, "interact_became_impossible")
+	Signals.Hud.connect(Signals.Hud.CLOSEST_INTERACTABLE_CHANGED, self, "show_interact_info")
 
 #Let the user know what interaction is possible.
-func show_interact_info( display_string : String ) -> void :
+func show_interact_info(new_interactable : Interactable) -> void :
+	#Hide the menu if there are no Interactables to interact with.
+	if new_interactable == null :
+		hide()
+		return
+	
 	text = "Press " 
-	text += OS.get_scancode_string(InputMap.get_action_list( "use" )[0].scancode)
-	text += " " + display_string
+	text += OS.get_scancode_string(InputMap.get_action_list("use")[0].scancode)
+	text += " to show InteractsMenu.\n"
+	text += "Press " + OS.get_scancode_string(InputMap.get_action_list("interact_with_closest")[0].scancode)
+	text += " to interact with " + new_interactable.title
 	show()
-
-func interact_became_impossible() -> void :
-	hide()

--- a/project.godot
+++ b/project.godot
@@ -1371,7 +1371,7 @@ jump={
 }
 toggle_fly={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":77,"unicode":0,"echo":false,"script":null)
  ]
 }
 player_toggleinput={
@@ -1597,6 +1597,11 @@ maneuver_lower={
 maneuver_lift_leg={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":55,"unicode":0,"echo":false,"script":null)
+ ]
+}
+interact_with_closest={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
  ]
 }
 


### PR DESCRIPTION
This PR is intended to make stair climbing Interactables feel more natural to use. 
 When completed, it will display to the player what is the closest Interactable.

This adds the action "interact_with_closest" and uses the keyboard key F
"toggle_fly" action has been changed to use the M key.

resolves #462 