### PR TITLE
HudCrosshair hides itself when mouse is active

### DIFF
--- a/SceneComponent/Interface/Hud/CrosshairRayCast.gd
+++ b/SceneComponent/Interface/Hud/CrosshairRayCast.gd
@@ -32,10 +32,10 @@ func _physics_process(_delta : float) -> void:
 		Signals.Hud.emit_signal(Signals.Hud.SET_FIRST_PERSON_POSSIBLE_CLICK, false)
 
 func _ready() :
-	set_process_unhandled_input(false)
+	set_process_input(false)
 
 func enable() -> void :
-	set_process_unhandled_input(true)
+	set_process_input(true)
 
 func disable() -> void :
-	set_process_unhandled_input(false)
+	set_process_input(false)

--- a/SceneComponent/Interface/Hud/HudCrosshair.gd
+++ b/SceneComponent/Interface/Hud/HudCrosshair.gd
@@ -3,6 +3,9 @@ extends TextureRect
 
 var camera : Camera
 
+#Determines when I am active or not.
+var is_active : bool = false
+
 #How many click events are currently possible.
 #Animation will play until the integer is set to zero.
 var clicks_possible : int = 0
@@ -30,6 +33,19 @@ func _click_possible(click_is_possible : bool) -> void :
 			margin_left = -5
 			margin_right = 5
 
+#Hide or show myself based on mouse captured state while in first person.
+func _mouse_capture_set(is_captured : bool) -> void :
+	#Do not show myself unless in first person mode.
+	if not is_active :
+		return
+	
+	if is_captured :
+		show()
+		ray_cast.enable()
+	else :
+		hide()
+		ray_cast.disable()
+
 func _physics_process(_delta) -> void :
 	var current_camera : Camera = get_tree().root.get_camera()
 	if current_camera != camera :
@@ -45,10 +61,14 @@ func _physics_process(_delta) -> void :
 func _ready() -> void :
 	Signals.Hud.connect(Signals.Hud.SET_FIRST_PERSON, self, "_set_crosshair")
 	Signals.Hud.connect(Signals.Hud.SET_FIRST_PERSON_POSSIBLE_CLICK, self, "_click_possible")
+	
+	#This hides me when in first person mode and the mouse is active.
+	Signals.Menus.connect(Signals.Menus.SET_MOUSE_TO_CAPTURED, self, "_mouse_capture_set")
 
 # Determines if I should turn on when requested or not.
-func _set_crosshair(is_active : bool) -> void :
-	if is_active :
+func _set_crosshair(activity_set : bool) -> void :
+	is_active = activity_set
+	if activity_set :
 		show()
 		Helpers.capture_mouse(true)
 #		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)

--- a/Script/Manager/Helpers.gd
+++ b/Script/Manager/Helpers.gd
@@ -16,7 +16,9 @@ func capture_mouse(capture_mouse : bool) -> void :
 	if capture_mouse == true :
 		is_capture_mode = true
 		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+		Signals.Menus.emit_signal("set_mouse_to_captured", true)
 	
 	else :
 		is_capture_mode = false
 		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+		Signals.Menus.emit_signal("set_mouse_to_captured", false)

--- a/Script/Manager/SignalsManager/MenuSignals.gd
+++ b/Script/Manager/SignalsManager/MenuSignals.gd
@@ -3,3 +3,9 @@ class_name MenuSignals
 
 ### Until we or godot implements proper class_name handling
 const name = "Menus"
+
+
+const SET_MOUSE_TO_CAPTURED : String = "set_mouse_to_captured"
+
+#Called when the mouse is set to either captured (true) or anything else (false)
+signal set_mouse_to_captured(is_captured_bool)


### PR DESCRIPTION
I added the signal that HudCrosshair listens for in MenuSignals. My reasoning was that menus, like the new uis, would need it too. I can move it to HudSignals if need be.

resolves #545 