### PR TITLE
Change material on pool water of LOD1 and LOD2 of RecHab1

### DIFF
--- a/Assets/MoonTown/Constructs/Rec_Hab_1/Rec_Hab_1.glb
+++ b/Assets/MoonTown/Constructs/Rec_Hab_1/Rec_Hab_1.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34b11bcc7f7dd707d852565ebd4e961b1d1925fec4382a9e5e40bfca19782f66
-size 7461168
+oid sha256:ebfaebe9226c7bc5ab0da38bd63aee83b45fae9118bc4ea88bd37010ec668ed9
+size 7420884

--- a/Assets/MoonTown/Constructs/Rec_Hab_1/Rec_Hab_1.tscn
+++ b/Assets/MoonTown/Constructs/Rec_Hab_1/Rec_Hab_1.tscn
@@ -26,6 +26,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 3
 generate_editor_visual = false
 
@@ -35,6 +36,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 3
 generate_editor_visual = false
 
@@ -44,6 +46,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 3
 generate_editor_visual = false
 
@@ -53,6 +56,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 9
 generate_editor_visual = false
 
@@ -62,6 +66,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 9
 generate_editor_visual = false
 
@@ -71,6 +76,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 1
 generate_editor_visual = false
 
@@ -80,6 +86,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 4
 generate_editor_visual = false
 
@@ -92,6 +99,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 1
 generate_editor_visual = false
 
@@ -100,6 +108,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 11
 generate_editor_visual = false
 
@@ -109,6 +118,7 @@ display_info = "Interactable"
 title = "Title"
 networked = true
 interactions_active = true
+stair_top_length = 1.0
 stairs_step_count = 11
 generate_editor_visual = false
 

--- a/Assets/MoonTown/Constructs/Rec_Hab_1/Water_001.material
+++ b/Assets/MoonTown/Constructs/Rec_Hab_1/Water_001.material
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efe711aa7fac440939b14972d385e607da3c23c8e75b7c0b05fedf2f7845ca92
-size 4196431
+oid sha256:28702fd899e8bdc6b5c37e61f549a1d8abcb8b40b45a79a32564a875ab7793fb
+size 882


### PR DESCRIPTION
This removed a utility texture used for UV work in Blender from the pool water material for the LOD1 and LOD2 version of RecHab1.

This time it's been checked in game and everything is fine. 
Ready for merge. 