### PR TITLE
Add Intro-Slide-6 to welcome-presentation in First Gallery Upper

### DIFF
--- a/Assets/SharedAssets/Textures/ImageTextures/Intro-Slide-6.jpg
+++ b/Assets/SharedAssets/Textures/ImageTextures/Intro-Slide-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c016f8a7a58c4a2832b910b836f67936b3d4bff351a29693679f855ef8e51b17
+size 248215

--- a/Assets/SharedAssets/Textures/ImageTextures/Intro-Slide-6.jpg.import
+++ b/Assets/SharedAssets/Textures/ImageTextures/Intro-Slide-6.jpg.import
@@ -1,0 +1,36 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path.s3tc="res://.import/Intro-Slide-6.jpg-0fc7ded6bf3c22df5939a139a227b1d9.s3tc.stex"
+path.etc2="res://.import/Intro-Slide-6.jpg-0fc7ded6bf3c22df5939a139a227b1d9.etc2.stex"
+metadata={
+"imported_formats": [ "s3tc", "etc2" ],
+"vram_texture": true
+}
+
+[deps]
+
+source_file="res://Assets/SharedAssets/Textures/ImageTextures/Intro-Slide-6.jpg"
+dest_files=[ "res://.import/Intro-Slide-6.jpg-0fc7ded6bf3c22df5939a139a227b1d9.s3tc.stex", "res://.import/Intro-Slide-6.jpg-0fc7ded6bf3c22df5939a139a227b1d9.etc2.stex" ]
+
+[params]
+
+compress/mode=2
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=2
+flags/repeat=1
+flags/filter=true
+flags/mipmaps=true
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/Tree/World/Moon_Town_Main.tscn
+++ b/Tree/World/Moon_Town_Main.tscn
@@ -29,4 +29,4 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 10.5586, -0.00645447, 2.45308 
 [node name="SpawnPoints" type="Spatial" parent="."]
 
 [node name="1" type="Position3D" parent="SpawnPoints"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -23.3474, 111.42, -167.176 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -33.9664, 89.0981, -164.65 )


### PR DESCRIPTION
A new image has been added to the SharedAssets / Textures / ImageTextures folder, Intro-Slide-6, and that image is now part of the welcome-presentation node of First_Gallery_Upper, which is an instance of Billboard.tscn

These images take a long time to set up, and so I'm now doing them one at a time, as time seems available.

So, this can be merged. I'll make a new PR once I have another image to add.