### PR TITLE
Simulate Airlock #707

### DIFF
--- a/SceneComponent/Object/Airlock/Airlock.tscn
+++ b/SceneComponent/Object/Airlock/Airlock.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
+[ext_resource path="res://SceneComponent/Object/Airlock/AirlockManager.gd" type="Script" id=1]
 [ext_resource path="res://Assets/MoonTown/Models/Airlock/LOD1.scn" type="PackedScene" id=3]
 [ext_resource path="res://SceneComponent/Object/Airlock/AirlockDoorInteractable.tscn" type="PackedScene" id=4]
 [ext_resource path="res://Assets/MoonTown/Models/Airlock/LOD0.scn" type="PackedScene" id=5]
@@ -45,6 +46,7 @@ tracks/0/keys = {
 script = ExtResource( 8 )
 
 [node name="LOD0" parent="." instance=ExtResource( 5 )]
+script = ExtResource( 1 )
 
 [node name="AirlockDoor_Exterior_LOD0" parent="LOD0" index="0"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00488389, 1.58298, 0.237398 )

--- a/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
+++ b/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
@@ -3,6 +3,13 @@ class_name AirlockDoorInteractable
 
 export(NodePath) var animation_player_path
 export(NodePath) var dock_point_path
+#Emitted when entity interacts with me while open.
+signal closed()
+#Emitted when entity interacts with me while closed.
+signal opened()
+#Emitted when I am completely closed and will not let air out.
+signal sealed()
+
 export(String) var animation_name
 # If this door is dockable to a passenger pod
 export(bool) var is_dock_door: bool = false
@@ -12,33 +19,37 @@ onready var dock_point = get_node_or_null(dock_point_path)
 
 var is_open: bool = false
 
+#Called when an airlock has finished opening or shutting.
+func _animation_finished(_anim_name) -> void :
+	emit_signal("sealed")
+	
+	anim.disconnect("animation_finished", self, "_animation_finished")
 
 func _ready():
 	title = "Airlock Dock"
-	
 
 func interact_with(_interactor : Node) -> void :
-	update_door()
-
-func open():
-	anim.play(animation_name, -1, 0.65, false)
-
-func close():
-	anim.play(animation_name, -1, -0.65, true)
-
-func update_door():
-	if !is_open:
-		open()
-	else:
-		close()
-	is_open = !is_open
+        if is_open:
+                emit_signal("closed")
+        else:
+                emit_signal("opened")
 
 puppet func netsync_door(val):
 	if val == is_open:
 		return
 	else:
-		update_door()
+		emit_signal("opened")
 
 func sync_for_new_player(peer_id):
 	rpc_id(peer_id, "netsync_door", is_open )
+
+func open():
+	anim.play(animation_name, -1, 0.65, false)
+	is_open = true
+
+func close():
+	anim.play(animation_name, -1, -0.65, true)
+	is_open = false
 	
+	if not anim.is_connected("animation_finished", self, "_animation_finished") :
+		anim.connect("animation_finished", self, "_animation_finished")

--- a/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
+++ b/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
@@ -8,7 +8,9 @@ signal closed()
 #Emitted when entity interacts with me while closed.
 signal opened()
 #Emitted when I am completely closed and will not let air out.
-signal sealed()
+signal finished()
+
+const FINISHED : String = "finished"
 
 export(String) var animation_name
 # If this door is dockable to a passenger pod
@@ -21,12 +23,13 @@ var is_open: bool = false
 
 #Called when an airlock has finished opening or shutting.
 func _animation_finished(_anim_name) -> void :
-	emit_signal("sealed")
-	
-	anim.disconnect("animation_finished", self, "_animation_finished")
+	emit_signal("finished")
 
 func _ready():
 	title = "Airlock Dock"
+	
+	#Listen for when animations are finished
+	anim.connect("animation_finished", self, "_animation_finished")
 
 func interact_with(_interactor : Node) -> void :
 		if is_open:
@@ -50,6 +53,3 @@ func open():
 func close():
 	anim.play(animation_name, -1, -0.65, true)
 	is_open = false
-	
-	if not anim.is_connected("animation_finished", self, "_animation_finished") :
-		anim.connect("animation_finished", self, "_animation_finished")

--- a/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
+++ b/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
@@ -29,10 +29,10 @@ func _ready():
 	title = "Airlock Dock"
 
 func interact_with(_interactor : Node) -> void :
-        if is_open:
-                emit_signal("closed")
-        else:
-                emit_signal("opened")
+		if is_open:
+				emit_signal("closed")
+		else:
+				emit_signal("opened")
 
 puppet func netsync_door(val):
 	if val == is_open:

--- a/SceneComponent/Object/Airlock/AirlockManager.gd
+++ b/SceneComponent/Object/Airlock/AirlockManager.gd
@@ -12,7 +12,7 @@ var processing_door : bool = false
 func _ready() -> void :
 	var airlock_array : Array
 	airlock_array = [$AirlockDoor_Exterior_LOD0/AirlockDoorInteractable,
-	$AirlockDoor_Interior_LOD0/AirlockDoorInteractable2]
+	$AirlockDoor_Interior_LOD0/AirlockDoorInteractable]
 	
 	for airlock in airlock_array :
 		airlock.connect("opened", self, "_airlock_opened", [airlock])

--- a/SceneComponent/Object/Airlock/AirlockManager.gd
+++ b/SceneComponent/Object/Airlock/AirlockManager.gd
@@ -10,11 +10,14 @@ func _ready() -> void :
 	
 	for airlock in airlock_array :
 		airlock.connect("opened", self, "_airlock_opened", [airlock])
-		airlock.connect("closed", self, "_airlock_closed")
+		airlock.connect("closed", self, "_airlock_closed", [airlock])
 
 #Called when something interacts with an open airlock door.
-func _airlock_closed() -> void :
+func _airlock_closed(airlock : AirlockDoorInteractable) -> void :
 	open_airlock = null
+	
+	#Close the airlock
+	airlock.close()
 
 #Called when something interacts with a closed airlock door.
 func _airlock_opened(airlock : AirlockDoorInteractable) -> void :

--- a/SceneComponent/Object/Airlock/AirlockManager.gd
+++ b/SceneComponent/Object/Airlock/AirlockManager.gd
@@ -1,0 +1,31 @@
+extends Spatial
+
+var open_airlock : AirlockDoorInteractable = null
+
+#Listen for the airlock doors being open or closed.
+func _ready() -> void :
+	var airlock_array : Array
+	airlock_array = [$AirlockDoor_Exterior_LOD0/AirlockDoorInteractable,
+	$AirlockDoor_Interior_LOD0/AirlockDoorInteractable2]
+	
+	for airlock in airlock_array :
+		airlock.connect("opened", self, "_airlock_opened", [airlock])
+		airlock.connect("closed", self, "_airlock_closed")
+
+#Called when something interacts with an open airlock door.
+func _airlock_closed() -> void :
+	open_airlock = null
+
+#Called when something interacts with a closed airlock door.
+func _airlock_opened(airlock : AirlockDoorInteractable) -> void :
+	#Don't do anything if the airlock is already being opened.
+	if airlock == open_airlock :
+		return
+	
+	#Close the other airlock door if it is open.
+	if not open_airlock == null :
+		open_airlock.close()
+		yield(open_airlock, "sealed")
+	
+	open_airlock = airlock
+	open_airlock.open()

--- a/SceneComponent/Object/Airlock/AirlockManager.gd
+++ b/SceneComponent/Object/Airlock/AirlockManager.gd
@@ -1,6 +1,12 @@
 extends Spatial
 
+#A door that has been requested to close by an entity will make this get emitted when the door is sealed.
+signal airlock_sealed()
+
 var open_airlock : AirlockDoorInteractable = null
+
+#Determines when you should wait until the door has finished closing.
+var processing_door : bool = false
 
 #Listen for the airlock doors being open or closed.
 func _ready() -> void :
@@ -10,25 +16,48 @@ func _ready() -> void :
 	
 	for airlock in airlock_array :
 		airlock.connect("opened", self, "_airlock_opened", [airlock])
-		airlock.connect("closed", self, "_airlock_closed", [airlock])
+		airlock.connect("closed", self, "_airlock_closed")
 
 #Called when something interacts with an open airlock door.
-func _airlock_closed(airlock : AirlockDoorInteractable) -> void :
-	open_airlock = null
+func _airlock_closed() -> void :
+	#If a door is processing movement, drop the call.
+	if processing_door :
+		return
 	
 	#Close the airlock
-	airlock.close()
+	open_airlock.close()
+	
+	#Wait until the airlock is sealed before opening another airlock.
+	processing_door = true
+	open_airlock.connect(open_airlock.FINISHED, self, "_airlock_finished_sealing")
+
+#Airlock has finished opening fully.
+func _airlock_finished_opening(airlock : AirlockDoorInteractable) -> void :
+	processing_door = false
+	airlock.disconnect(airlock.FINISHED, self, "_airlock_finished_opening")
+
+#When a player closes a door this function will go off letting us know the door is sealed.
+func _airlock_finished_sealing() -> void :
+	processing_door = false
+	open_airlock.disconnect(open_airlock.FINISHED, self, "_airlock_finished_sealing")
+	emit_signal("airlock_sealed")
+	open_airlock = null
 
 #Called when something interacts with a closed airlock door.
 func _airlock_opened(airlock : AirlockDoorInteractable) -> void :
-	#Don't do anything if the airlock is already being opened.
-	if airlock == open_airlock :
+	#If a door is processing movement, drop the call.
+	if processing_door :
 		return
 	
 	#Close the other airlock door if it is open.
 	if not open_airlock == null :
-		open_airlock.close()
-		yield(open_airlock, "sealed")
+		_airlock_closed()
+		yield(open_airlock, open_airlock.FINISHED)
 	
+	#Finally open the requested door.
 	open_airlock = airlock
 	open_airlock.open()
+	
+	#Listen for when the door is finished opening.
+	processing_door = true
+	open_airlock.connect(open_airlock.FINISHED, self, "_airlock_finished_opening", [open_airlock])


### PR DESCRIPTION
QA checks: 
Test that airlocks openings are networked and that the simulation is played for everyone. Passed.
Test that client will have airlock synced even when the airlock is animating for other players. Probably passed. Might need more testing.

resolves #707 