### PR TITLE
Memory leak and orphaned nodes fix

### DIFF
--- a/SceneComponent/Actor/AI/MwAI.gd
+++ b/SceneComponent/Actor/AI/MwAI.gd
@@ -52,3 +52,4 @@ func _on_request_rejected():
 
 func _on_worker_assigned(where):
 	BehaviorTree.emit_signal("workstation_assigned", where)
+

--- a/Script/Network/NetworkManager/ANetworkInstance.gd
+++ b/Script/Network/NetworkManager/ANetworkInstance.gd
@@ -18,7 +18,7 @@ func _ready() -> void:
 	world = yield(Scene.change_scene_to_async(Scene.world_scene), "scene_changed")
 	
 	world.name = "World"
-
+	world.connect("tree_exited", self, "_on_world_closed")
 	entities_container = Node.new()
 	entities_container.name = "entities"
 	world.add_child(entities_container)
@@ -111,3 +111,6 @@ puppet func _client_crpc_signal(params: Array):
 		
 	Log.trace(self, "", "Received RPC signal - params: %s" % [params])
 	Signals.get(str(params[0])).emit_signal(params[1], params[2])
+
+func _on_world_closed():
+	queue_free()

--- a/addons/joyeux_npc_editor/src/Core/Control_Components/BehaviorNode.gd
+++ b/addons/joyeux_npc_editor/src/Core/Control_Components/BehaviorNode.gd
@@ -40,7 +40,6 @@ func  _on_disconnected_from(_slot:int):
 					Nodes.Color(Nodes.TYPE_ANY))
 
 func _on_dropdown_change(type, slot):
-	print(type)
 	for slots in get_child_count():
 					set_slot(slots, 
 					is_slot_enabled_left(slots), 

--- a/addons/joyeux_npc_editor/src/Core/Control_Components/FileSeparator.gd
+++ b/addons/joyeux_npc_editor/src/Core/Control_Components/FileSeparator.gd
@@ -1,31 +1,32 @@
 tool
 extends HBoxContainer
 class_name FileLabel
-
-
+var Dialog
+var Text
 func _init(filters = ""):
 	if filters != "":
 		var button = Button.new()
 		button.text = "Open..."
 		button.name = "Button"
-		var Dialog = FileDialog.new()
+		Dialog = FileDialog.new()
 		Dialog.mode = 0
 		Dialog.filters = filters.rsplit(",")
 		Dialog.name = "OpenFile"
-		Dialog.rect_min_size = Vector2(100,250)
-		var text = LineEdit.new()
-		text.name = "Text"
-		text.editable = false
+		Text = LineEdit.new()
+		Text.name = "Text"
+		Text.editable = false
 		add_child(button)
-		add_child(text)
+		add_child(Text)
 		add_child(Dialog)
-	else:
-		yield(self, "ready")
-		var Dial = get_node("OpenFile")
-		get_node("Button").connect("pressed", self, "open_file")
-		Dial.connect("about_to_show", get_node("Text"), "clear")
-		Dial.connect("file_selected",  get_node("Text"), "append_at_cursor")
-		Dial.get_cancel().connect("pressed",  get_node("Text"), "clear")
+
+func _ready():
+	get_node("Button").connect("pressed", self, "open_file")
+	get_node("OpenFile").connect("about_to_show", get_node("Text"), "clear")
+	get_node("OpenFile").connect("file_selected",  get_node("Text"), "append_at_cursor")
+	get_node("OpenFile").get_cancel().connect("pressed",  get_node("Text"), "clear")
+	get_node("OpenFile").rect_min_size = Vector2(400,500)
+	get_node("Text").editable = false
+	pass
 
 func open_file():
 	get_node("OpenFile").popup_centered()

--- a/addons/joyeux_npc_editor/src/Core/Control_Components/SeparatedLabel.gd
+++ b/addons/joyeux_npc_editor/src/Core/Control_Components/SeparatedLabel.gd
@@ -2,7 +2,6 @@ tool
 extends HBoxContainer
 class_name DoubleLabel
 
-
 func get_class_dropdown(classname : String) -> Control:
 	if not Nodes.custom_types.has(classname):
 		return null
@@ -65,18 +64,25 @@ func filter_input_label(input : String) -> void:
 	if Label1 == null:
 		return
 	Label1.rect_min_size = Vector2(50,20)
-	Label1.size_flags_horizontal = SIZE_EXPAND_FILL
-	add_child(Label1)
+	Label1.name = "L_Label"
+	add_child(Label1, true)
 
 func _init(left_title : String = "", right_title : String = ""):
 	filter_input_label(left_title)
 	var Label2 = Label.new()
-	Label2.size_flags_horizontal = SIZE_EXPAND_FILL
+	Label2.name = "R_Label"
 	Label2.text = right_title
 	add_child(Label2)
-	
-func _ready():
-	#Deletion of children that come to existnece due to duplication
-	get_child(3).free()
-	get_child(2).free()
 
+func _ready():
+	get_node("R_Label").size_flags_horizontal = SIZE_EXPAND_FILL
+	get_node("L_Label").align= Label.ALIGN_LEFT
+	get_node("L_Label").size_flags_horizontal = SIZE_EXPAND_FILL
+
+func add_owners(ownr : Node):
+	set_owner(ownr)
+	for child in get_children():
+		child.set_owner(ownr)
+		if child.get_child_count()>0:
+			for sub_child in child.get_children():
+				sub_child.set_owner(ownr)

--- a/addons/joyeux_npc_editor/src/Core/Nodes.gd
+++ b/addons/joyeux_npc_editor/src/Core/Nodes.gd
@@ -51,6 +51,7 @@ var Graphs : Dictionary = {
 	}
 }
 
+var initiated : bool = false
 var custom_types : Dictionary = {}
 var user_override : String = "" 
 var proj_override : String = "" 
@@ -234,11 +235,12 @@ func Color(id) -> Color:
 	return Color(0)
 
 func initiate() -> void:
-	Definitions =  NpcDefinitions.new()
-	load_custom_paths()
-	_load_definitions()
-	_load_functions()
-	_load_signals()
+	if not initiated:
+		Definitions =  NpcDefinitions.new()
+		load_custom_paths()
+		_load_definitions()
+		_load_functions()
+		_load_signals()
 
 #	load_user_defined_nodes()
 """

--- a/addons/joyeux_npc_editor/src/Core/Nodes.gd
+++ b/addons/joyeux_npc_editor/src/Core/Nodes.gd
@@ -148,6 +148,8 @@ func _load_signals() -> void:
 	var signal_list : Dictionary = Definitions.get("_stimulus")
 	var signal_names : Array = signal_list.keys()
 	for signals in signal_names:
+		if Graphs.stimulus.has(signals):
+			continue
 		var data : Dictionary = signal_list.get(signals)
 		var current_node : GraphNode = GraphNode.new()
 		current_node.title = signals
@@ -166,6 +168,8 @@ func _load_functions() -> void:
 		return
 	for function in function_names:
 		var data : Dictionary = functions.get(function)
+		if Graphs.get(data.get("_category")).has(function):
+			continue
 		var current_node : GraphNode = BehaviorNode.new()
 		current_node.title = function
 		for ports in max(data.get("_input_ports").size(),data.get("_output_ports").size()):

--- a/addons/joyeux_npc_editor/src/Core/Nodes.gd
+++ b/addons/joyeux_npc_editor/src/Core/Nodes.gd
@@ -152,12 +152,17 @@ func _load_signals() -> void:
 			continue
 		var data : Dictionary = signal_list.get(signals)
 		var current_node : GraphNode = GraphNode.new()
+		var scene_to_save : PackedScene = PackedScene.new()
 		current_node.title = signals
-		current_node.add_child(DoubleLabel.new("", data.get("_output_name")))
+		var display_label = DoubleLabel.new("", data.get("_output_name"))
+		current_node.add_child(display_label, true)
+		display_label.add_owners(current_node)
 		current_node.set_slot(0,false,TYPE_NIL,0, true,
 			_get_type(data.get("_output_type")),  #the type may be a string, so we need to parse it
 			self.Color(data.get("_output_type"))) #Special case, color parses strings
-		Graphs.stimulus[signals]=current_node
+		scene_to_save.pack(current_node)
+		current_node.queue_free()
+		Graphs.stimulus[signals]=scene_to_save
 
 
 func _load_functions() -> void:
@@ -170,6 +175,7 @@ func _load_functions() -> void:
 		var data : Dictionary = functions.get(function)
 		if Graphs.get(data.get("_category")).has(function):
 			continue
+		var scene_to_save : PackedScene = PackedScene.new()
 		var current_node : GraphNode = BehaviorNode.new()
 		current_node.title = function
 		for ports in max(data.get("_input_ports").size(),data.get("_output_ports").size()):
@@ -181,18 +187,16 @@ func _load_functions() -> void:
 				_get_port_type(data, ports, false),
 				_get_port_type(data, ports, false),
 				self.Color(_get_port_type(data, ports, false)))
-			current_node.add_child(DoubleLabel.new(
+			var display_label = DoubleLabel.new(
 				_get_port_name(data, ports, true),
-				_get_port_name(data, ports, false)
-			))
+				_get_port_name(data, ports, false))
+			current_node.add_child(display_label, true)
+			display_label.add_owners(current_node)
 			#At this point we have created the node, let's store it
-		match data.get("_category"):
-			"inhibitors":
-				Graphs.inhibitors[function]=current_node
-			"actions":
-				Graphs.actions[function]=current_node
-			"misc":
-				Graphs.misc[function]=current_node
+		scene_to_save.pack(current_node)
+		current_node.queue_free()
+		Graphs[data.get("_category")][function]=scene_to_save
+
 
 
 func _load_definitions() -> void:

--- a/addons/joyeux_npc_editor/src/interface/behaviors/scenes/Behaviour_tree_editor.gd
+++ b/addons/joyeux_npc_editor/src/interface/behaviors/scenes/Behaviour_tree_editor.gd
@@ -62,6 +62,8 @@ func _on_Add_pressed() -> void:
 		instanced = instanced.instance()
 	instanced.name = instanced.title 
 	$ViewMenuSplit/GraphEdit.add_child(instanced)
+	if instanced.owner == null:
+		instanced.queue_free()
 	idx+=1
 	
 


### PR DESCRIPTION
Fixes an issue that duplicates the resources cached by the NPC editor and changes the way it stores them so they are freed upon exit, also avoids duplication of NetworkInstance.

There are 22 orphans to be removed before merging