### PR TITLE
Make AudioSphere's collisions bigger so they are easier to interact with

### DIFF
--- a/SceneComponent/Audio/AudioSphere/AudioSphere.tscn
+++ b/SceneComponent/Audio/AudioSphere/AudioSphere.tscn
@@ -7,7 +7,7 @@
 [ext_resource path="res://SceneComponent/Audio/AudioSphere/AudioSphereAnimations.gd" type="Script" id=5]
 
 [sub_resource type="BoxShape" id=1]
-extents = Vector3( 0.2, 0.2, 0.2 )
+extents = Vector3( 0.2, 1.10504, 0.2 )
 
 [sub_resource type="ArrayMesh" id=2]
 surfaces/0 = {


### PR DESCRIPTION
I didn't create the issue, but while working on #814 I found out interacting with the audospeheres was hard due to their small collision shape and their position, making you able to interact with it only being inside it