### PR TITLE
Fix Airlock and initial connection issues mostly

### DIFF
--- a/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
+++ b/SceneComponent/Object/Airlock/AirlockDoorInteractable.gd
@@ -46,6 +46,9 @@ puppet func netsync_door(val):
 		emit_signal("opened")
 
 func sync_for_new_player(peer_id):
+	#Major hack to prevent premature calling
+	yield(get_tree().create_timer(10), "timeout")
+	Log.trace(self, "sync_for_new_player", "Attempting sync %s for player %s" % [get_path(), str(peer_id)])
 	rpc_id(peer_id, "netsync_door", is_open )
 
 puppet func request_close():

--- a/project.godot
+++ b/project.godot
@@ -2311,6 +2311,8 @@ limits/message_queue/max_size_kb=2048
 
 [network]
 
+limits/tcp/connect_timeout_seconds=1800
+limits/packet_peer_stream/max_buffer_po2=32
 limits/debugger_stdout/max_chars_per_second=4096
 limits/debugger_stdout/max_messages_per_frame=1000
 limits/debugger_stdout/max_errors_per_second=10000


### PR DESCRIPTION
A very hacky workaround for Godot behaving differently for exported instanced. 
 It still fails to connect occasionally. But this will work well enough for the current alpha until we can get 0.2.1